### PR TITLE
Add Docker setup for supervisor and MCP server (Phase 6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # Git worktrees
 /.worktrees/
+
+# Sandbox proxy CA cert (build-time only, not committed)
+docker/proxy-ca.crt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,87 @@
+# VanPilot local development docker-compose.
+#
+# Services:
+#   supervisor — gRPC server on port 50051, manages agent sessions
+#   mcp        — MCP display-control server (stdio), used by agents
+#   agent      — tmux session for Claude Code agents
+#
+# Resource limits per DESIGN.md section 9.3: Docker resource limits
+# are the blast radius control for sandboxed agents.
+
+services:
+  supervisor:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.supervisor
+      args:
+        PROXY_CA_CERT: "${PROXY_CA_CERT:-}"
+    ports:
+      - "50051:50051"
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 1G
+        reservations:
+          cpus: "0.5"
+          memory: 256M
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c",
+        "import grpc; ch = grpc.insecure_channel('localhost:50051'); grpc.channel_ready_future(ch).result(timeout=5)"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    networks:
+      - vanpilot
+
+  mcp:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.mcp
+    # MCP server uses stdio — no ports exposed.
+    # In production, Claude Code spawns this process directly.
+    # Here we keep it as a buildable service for verification.
+    stdin_open: true
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512M
+        reservations:
+          cpus: "0.25"
+          memory: 128M
+    networks:
+      - vanpilot
+
+  agent:
+    image: python:3.12-slim
+    command: >
+      bash -c "
+        apt-get update && apt-get install -y --no-install-recommends tmux &&
+        rm -rf /var/lib/apt/lists/* &&
+        tmux new-session -d -s vanpilot-lead 'echo Agent session ready; exec bash' &&
+        echo 'Agent tmux session started' &&
+        tail -f /dev/null
+      "
+    volumes:
+      - ./.mcp.json:/workspace/.mcp.json:ro
+    working_dir: /workspace
+    depends_on:
+      supervisor:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: "4.0"
+          memory: 4G
+        reservations:
+          cpus: "1.0"
+          memory: 512M
+    networks:
+      - vanpilot
+
+networks:
+  vanpilot:
+    driver: bridge

--- a/docker/Dockerfile.mcp
+++ b/docker/Dockerfile.mcp
@@ -1,0 +1,21 @@
+# Dockerfile for the VanPilot MCP display-control server.
+#
+# The MCP server uses JSON-RPC 2.0 over stdio. It has no external
+# dependencies beyond the Python standard library.
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Copy MCP source
+COPY mcp/src/__init__.py mcp/src/__init__.py
+COPY mcp/src/server.py mcp/src/server.py
+COPY mcp/src/handlers.py mcp/src/handlers.py
+COPY mcp/src/tools.py mcp/src/tools.py
+
+ENV PYTHONPATH=/app
+
+# MCP server communicates over stdio, no ports needed.
+# The default command runs the server; in production this is invoked
+# by Claude Code via the .mcp.json config with stdin/stdout pipes.
+CMD ["python", "-m", "mcp.src.server"]

--- a/docker/Dockerfile.supervisor
+++ b/docker/Dockerfile.supervisor
@@ -1,0 +1,79 @@
+# Dockerfile for the VanPilot supervisor process.
+#
+# The supervisor serves gRPC on port 50051 and manages Claude Code
+# agent sessions via tmux. It requires grpcio and the generated
+# protobuf Python stubs.
+
+FROM python:3.12-slim AS builder
+
+# Configure proxy CA trust for sandbox environments.
+# proxy-ca.crt is copied from the build context (may be empty in prod).
+COPY docker/proxy-ca.crt* /tmp/
+RUN if [ -s /tmp/proxy-ca.crt ]; then \
+      cp /tmp/proxy-ca.crt /usr/local/share/ca-certificates/proxy-ca.crt && \
+      update-ca-certificates; \
+    fi
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+ENV PIP_CERT=/etc/ssl/certs/ca-certificates.crt
+
+# Install protoc via grpcio-tools for proto codegen
+RUN pip install --no-cache-dir grpcio-tools==1.72.0
+
+WORKDIR /build
+
+# Copy proto definitions and generate Python stubs
+COPY proto/vanpilot/v1/*.proto proto/vanpilot/v1/
+RUN python -m grpc_tools.protoc \
+    --proto_path=. \
+    --python_out=. \
+    proto/vanpilot/v1/sync.proto \
+    proto/vanpilot/v1/display.proto \
+    proto/vanpilot/v1/screenshot.proto
+
+# --- Runtime stage ---
+FROM python:3.12-slim
+
+# Configure proxy CA trust for sandbox environments
+COPY docker/proxy-ca.crt* /tmp/
+RUN if [ -s /tmp/proxy-ca.crt ]; then \
+      cp /tmp/proxy-ca.crt /usr/local/share/ca-certificates/proxy-ca.crt && \
+      update-ca-certificates; \
+    fi
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+ENV PIP_CERT=/etc/ssl/certs/ca-certificates.crt
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+# Match protobuf version to what grpcio-tools generates (6.x).
+# Use latest grpcio that works with protobuf 6.x.
+RUN pip install --no-cache-dir grpcio==1.72.0 protobuf>=6.30.0
+
+WORKDIR /app
+
+# Copy generated proto stubs from builder
+COPY --from=builder /build/proto/ proto/
+
+# Copy supervisor source
+COPY supervisor/src/__init__.py supervisor/src/__init__.py
+COPY supervisor/src/server.py supervisor/src/server.py
+COPY supervisor/src/sync_service.py supervisor/src/sync_service.py
+COPY supervisor/src/event_store.py supervisor/src/event_store.py
+COPY supervisor/src/tmux_launcher.py supervisor/src/tmux_launcher.py
+
+ENV PYTHONPATH=/app
+
+EXPOSE 50051
+
+CMD ["python", "-c", "\
+from supervisor.src.server import create_server; \
+import signal, sys; \
+server, port = create_server(50051); \
+server.start(); \
+print(f'Supervisor gRPC server listening on port {port}', flush=True); \
+signal.signal(signal.SIGTERM, lambda *_: (server.stop(5), sys.exit(0))); \
+server.wait_for_termination() \
+"]


### PR DESCRIPTION
## Summary

- **`docker/Dockerfile.supervisor`**: Multi-stage build — builder stage generates Python proto stubs via `grpcio-tools`, runtime stage runs the supervisor gRPC server on port 50051 with tmux installed for agent session management.
- **`docker/Dockerfile.mcp`**: Lightweight Python 3.12 image for the MCP display-control server. No external dependencies — communicates over stdio via JSON-RPC 2.0.
- **`docker-compose.yml`**: Orchestrates three services — supervisor (gRPC on 50051 with healthcheck), MCP (stdio), and agent (tmux session). All containers have CPU and memory resource limits per DESIGN.md section 9.3.
- **`.gitignore`**: Added `docker/proxy-ca.crt` (sandbox-specific, not committed).

## Verification

- Supervisor starts and serves gRPC inside Docker on port 50051
- `GetEvents` RPC returns all 3 hardcoded events (2 TextMessage, 1 WatchdogTimeout)
- MCP server responds correctly to `initialize`, `tools/list`, and `tools/call` over stdio
- Both images build cleanly with `docker build`

## Resource Limits

| Service | CPU Limit | Memory Limit |
|---------|-----------|-------------|
| supervisor | 2.0 | 1G |
| mcp | 1.0 | 512M |
| agent | 4.0 | 4G |

## Test plan

- [x] `docker build -f docker/Dockerfile.supervisor .` succeeds
- [x] `docker build -f docker/Dockerfile.mcp .` succeeds
- [x] Supervisor container starts and prints "listening on port 50051"
- [x] gRPC GetEvents returns 3 hardcoded events from inside the container
- [x] MCP server responds to JSON-RPC initialize, tools/list, tools/call
- [ ] `docker compose up` brings up all three services (requires Docker Compose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)