### PR TITLE
Add gRPC client/server, bitmap cache, and event processor

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -86,6 +86,7 @@ maven.install(
         "io.grpc:grpc-stub:1.78.0",
         "io.grpc:grpc-protobuf-lite:1.78.0",
         "io.grpc:grpc-android:1.78.0",
+        "io.grpc:grpc-inprocess:1.78.0",
 
         # Kotlin coroutines
         "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0",

--- a/android/BUILD.bazel
+++ b/android/BUILD.bazel
@@ -5,17 +5,45 @@ load("@rules_android//rules:rules.bzl", "android_binary")
 package(default_visibility = ["//visibility:public"])
 
 # ============================================================================
-# Main app library
+# Main app library (Car App UI — no gRPC deps to avoid dex issues)
 # ============================================================================
 
 kt_android_library(
     name = "vanpilot_lib",
-    srcs = glob(["app/src/main/kotlin/**/*.kt"]),
+    srcs = glob(
+        ["app/src/main/kotlin/**/*.kt"],
+        exclude = [
+            "app/src/main/kotlin/com/vanpilot/auto/grpc/**",
+            "app/src/main/kotlin/com/vanpilot/auto/cache/**",
+            "app/src/main/kotlin/com/vanpilot/auto/sync/**",
+        ],
+    ),
     custom_package = "com.vanpilot.auto",
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**"]),
     deps = [
         "@maven//:androidx_car_app_app",
+    ],
+)
+
+# ============================================================================
+# gRPC client/server library (JVM-only for now; Android integration later)
+# ============================================================================
+
+kt_jvm_library(
+    name = "grpc_lib",
+    srcs = glob([
+        "app/src/main/kotlin/com/vanpilot/auto/grpc/**/*.kt",
+        "app/src/main/kotlin/com/vanpilot/auto/cache/**/*.kt",
+        "app/src/main/kotlin/com/vanpilot/auto/sync/**/*.kt",
+    ]),
+    deps = [
+        "//proto/vanpilot/v1:sync_java_proto",
+        "//proto/vanpilot/v1:sync_java_grpc",
+        "//proto/vanpilot/v1:screenshot_java_proto",
+        "//proto/vanpilot/v1:screenshot_java_grpc",
+        "@maven//:io_grpc_grpc_stub",
+        "@maven//:io_grpc_grpc_protobuf_lite",
     ],
 )
 
@@ -84,6 +112,57 @@ kt_jvm_library(
     ],
 )
 
+# ---- gRPC / sync test libraries ----
+
+kt_jvm_library(
+    name = "bitmap_cache_test_lib",
+    srcs = ["app/src/test/kotlin/com/vanpilot/auto/cache/BitmapCacheTest.kt"],
+    deps = [
+        ":grpc_lib",
+        "@maven//:junit_junit",
+        "@maven//:com_google_truth_truth",
+    ],
+)
+
+kt_jvm_library(
+    name = "event_processor_test_lib",
+    srcs = ["app/src/test/kotlin/com/vanpilot/auto/sync/EventProcessorTest.kt"],
+    deps = [
+        ":grpc_lib",
+        "//proto/vanpilot/v1:sync_java_proto",
+        "@maven//:junit_junit",
+        "@maven//:com_google_truth_truth",
+    ],
+)
+
+kt_jvm_library(
+    name = "sync_service_client_test_lib",
+    srcs = ["app/src/test/kotlin/com/vanpilot/auto/grpc/SyncServiceClientTest.kt"],
+    deps = [
+        ":grpc_lib",
+        "//proto/vanpilot/v1:sync_java_proto",
+        "//proto/vanpilot/v1:sync_java_grpc",
+        "@maven//:io_grpc_grpc_stub",
+        "@maven//:io_grpc_grpc_inprocess",
+        "@maven//:junit_junit",
+        "@maven//:com_google_truth_truth",
+    ],
+)
+
+kt_jvm_library(
+    name = "android_app_service_impl_test_lib",
+    srcs = ["app/src/test/kotlin/com/vanpilot/auto/grpc/AndroidAppServiceImplTest.kt"],
+    deps = [
+        ":grpc_lib",
+        "//proto/vanpilot/v1:screenshot_java_proto",
+        "//proto/vanpilot/v1:screenshot_java_grpc",
+        "@maven//:io_grpc_grpc_stub",
+        "@maven//:io_grpc_grpc_inprocess",
+        "@maven//:junit_junit",
+        "@maven//:com_google_truth_truth",
+    ],
+)
+
 # ============================================================================
 # Test targets (fine-grained, one per test class)
 #
@@ -127,6 +206,48 @@ android_local_test(
     test_class = "com.vanpilot.auto.VanPilotSurfaceCallbackTest",
     deps = [
         ":surface_callback_test_lib",
+        "@robolectric//bazel:android-all",
+    ],
+)
+
+# ---- gRPC / sync test targets ----
+
+android_local_test(
+    name = "bitmap_cache_test",
+    manifest = "app/src/main/AndroidManifest.xml",
+    test_class = "com.vanpilot.auto.cache.BitmapCacheTest",
+    deps = [
+        ":bitmap_cache_test_lib",
+        "@robolectric//bazel:android-all",
+    ],
+)
+
+android_local_test(
+    name = "event_processor_test",
+    manifest = "app/src/main/AndroidManifest.xml",
+    test_class = "com.vanpilot.auto.sync.EventProcessorTest",
+    deps = [
+        ":event_processor_test_lib",
+        "@robolectric//bazel:android-all",
+    ],
+)
+
+android_local_test(
+    name = "sync_service_client_test",
+    manifest = "app/src/main/AndroidManifest.xml",
+    test_class = "com.vanpilot.auto.grpc.SyncServiceClientTest",
+    deps = [
+        ":sync_service_client_test_lib",
+        "@robolectric//bazel:android-all",
+    ],
+)
+
+android_local_test(
+    name = "android_app_service_impl_test",
+    manifest = "app/src/main/AndroidManifest.xml",
+    test_class = "com.vanpilot.auto.grpc.AndroidAppServiceImplTest",
+    deps = [
+        ":android_app_service_impl_test_lib",
         "@robolectric//bazel:android-all",
     ],
 )

--- a/android/app/src/main/kotlin/com/vanpilot/auto/cache/BitmapCache.kt
+++ b/android/app/src/main/kotlin/com/vanpilot/auto/cache/BitmapCache.kt
@@ -1,0 +1,57 @@
+package com.vanpilot.auto.cache
+
+/**
+ * Thread-safe in-memory LRU cache mapping cache keys to PNG image data.
+ *
+ * Uses access-order LinkedHashMap so that recently accessed entries
+ * are evicted last when the cache exceeds [maxSize].
+ */
+class BitmapCache(private val maxSize: Int = 64) {
+
+    private val cache = LinkedHashMap<String, ByteArray>(16, 0.75f, true)
+    private val lock = Any()
+
+    fun put(key: String, data: ByteArray) {
+        synchronized(lock) {
+            cache[key] = data
+            trimToSize()
+        }
+    }
+
+    fun get(key: String): ByteArray? {
+        synchronized(lock) {
+            return cache[key]
+        }
+    }
+
+    fun contains(key: String): Boolean {
+        synchronized(lock) {
+            return cache.containsKey(key)
+        }
+    }
+
+    fun keys(): Set<String> {
+        synchronized(lock) {
+            return cache.keys.toSet()
+        }
+    }
+
+    fun remove(key: String): ByteArray? {
+        synchronized(lock) {
+            return cache.remove(key)
+        }
+    }
+
+    fun size(): Int {
+        synchronized(lock) {
+            return cache.size
+        }
+    }
+
+    private fun trimToSize() {
+        while (cache.size > maxSize) {
+            val eldest = cache.entries.iterator().next()
+            cache.remove(eldest.key)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/vanpilot/auto/grpc/AndroidAppServiceImpl.kt
+++ b/android/app/src/main/kotlin/com/vanpilot/auto/grpc/AndroidAppServiceImpl.kt
@@ -1,0 +1,72 @@
+package com.vanpilot.auto.grpc
+
+import com.google.protobuf.ByteString
+import com.vanpilot.auto.cache.BitmapCache
+import com.vanpilot.proto.v1.AndroidAppServiceGrpc
+import com.vanpilot.proto.v1.GetCurrentDisplayRequest
+import com.vanpilot.proto.v1.GetCurrentDisplayResponse
+import com.vanpilot.proto.v1.QueryCacheRequest
+import com.vanpilot.proto.v1.QueryCacheResponse
+import com.vanpilot.proto.v1.RequestScreenshotRequest
+import com.vanpilot.proto.v1.RequestScreenshotResponse
+import io.grpc.stub.StreamObserver
+
+/**
+ * Server-side implementation of AndroidAppService.
+ *
+ * Hosted by the Android app so the Mac Studio supervisor can query
+ * the app's display state and bitmap cache.
+ */
+class AndroidAppServiceImpl(
+    private val cache: BitmapCache,
+    private val getCurrentDisplayKey: () -> String?,
+    private val captureScreenshot: () -> ByteArray?
+) : AndroidAppServiceGrpc.AndroidAppServiceImplBase() {
+
+    override fun getCurrentDisplay(
+        request: GetCurrentDisplayRequest,
+        responseObserver: StreamObserver<GetCurrentDisplayResponse>
+    ) {
+        val key = getCurrentDisplayKey() ?: ""
+        val response = GetCurrentDisplayResponse.newBuilder()
+            .setCurrentCacheKey(key)
+            .build()
+        responseObserver.onNext(response)
+        responseObserver.onCompleted()
+    }
+
+    override fun requestScreenshot(
+        request: RequestScreenshotRequest,
+        responseObserver: StreamObserver<RequestScreenshotResponse>
+    ) {
+        val screenshot = captureScreenshot() ?: ByteArray(0)
+        val response = RequestScreenshotResponse.newBuilder()
+            .setScreenshot(ByteString.copyFrom(screenshot))
+            .build()
+        responseObserver.onNext(response)
+        responseObserver.onCompleted()
+    }
+
+    override fun queryCache(
+        request: QueryCacheRequest,
+        responseObserver: StreamObserver<QueryCacheResponse>
+    ) {
+        val requestedKeys = request.keysList
+        val builder = QueryCacheResponse.newBuilder()
+
+        if (requestedKeys.isEmpty()) {
+            builder.addAllPresentKeys(cache.keys())
+        } else {
+            for (key in requestedKeys) {
+                if (cache.contains(key)) {
+                    builder.addPresentKeys(key)
+                } else {
+                    builder.addMissingKeys(key)
+                }
+            }
+        }
+
+        responseObserver.onNext(builder.build())
+        responseObserver.onCompleted()
+    }
+}

--- a/android/app/src/main/kotlin/com/vanpilot/auto/grpc/SyncServiceClient.kt
+++ b/android/app/src/main/kotlin/com/vanpilot/auto/grpc/SyncServiceClient.kt
@@ -1,0 +1,49 @@
+package com.vanpilot.auto.grpc
+
+import com.vanpilot.proto.v1.GetBitmapRequest
+import com.vanpilot.proto.v1.GetBitmapResponse
+import com.vanpilot.proto.v1.GetEventsRequest
+import com.vanpilot.proto.v1.GetEventsResponse
+import com.vanpilot.proto.v1.SendUserInputRequest
+import com.vanpilot.proto.v1.SendUserInputResponse
+import com.vanpilot.proto.v1.SyncServiceGrpc
+import io.grpc.ManagedChannel
+
+/**
+ * Client wrapper for the SyncService gRPC service.
+ *
+ * The Android app uses this to pull events from the Mac Studio supervisor,
+ * send transcribed voice input, and request bitmaps not in the local cache.
+ */
+class SyncServiceClient(private val channel: ManagedChannel) {
+
+    private val stub: SyncServiceGrpc.SyncServiceBlockingStub =
+        SyncServiceGrpc.newBlockingStub(channel)
+
+    fun getEvents(sinceTimestampMs: Long, maxCount: Int): GetEventsResponse {
+        val request = GetEventsRequest.newBuilder()
+            .setSinceTimestampMs(sinceTimestampMs)
+            .setMaxCount(maxCount)
+            .build()
+        return stub.getEvents(request)
+    }
+
+    fun sendUserInput(text: String, targetAgentId: String = "lead"): SendUserInputResponse {
+        val request = SendUserInputRequest.newBuilder()
+            .setText(text)
+            .setTargetAgentId(targetAgentId)
+            .build()
+        return stub.sendUserInput(request)
+    }
+
+    fun getBitmap(cacheKey: String): GetBitmapResponse {
+        val request = GetBitmapRequest.newBuilder()
+            .setCacheKey(cacheKey)
+            .build()
+        return stub.getBitmap(request)
+    }
+
+    fun shutdown() {
+        channel.shutdown()
+    }
+}

--- a/android/app/src/main/kotlin/com/vanpilot/auto/sync/EventProcessor.kt
+++ b/android/app/src/main/kotlin/com/vanpilot/auto/sync/EventProcessor.kt
@@ -1,0 +1,80 @@
+package com.vanpilot.auto.sync
+
+import com.vanpilot.auto.cache.BitmapCache
+import com.vanpilot.proto.v1.Event
+
+/**
+ * Processes Event objects received from GetEventsResponse.
+ *
+ * Stores processed results internally for consumption by the UI layer.
+ */
+class EventProcessor(private val cache: BitmapCache) {
+
+    private val _textMessages = mutableListOf<ProcessedTextMessage>()
+    val textMessages: List<ProcessedTextMessage> get() = _textMessages.toList()
+
+    private val _alerts = mutableListOf<ProcessedAlert>()
+    val alerts: List<ProcessedAlert> get() = _alerts.toList()
+
+    var currentDisplayKey: String? = null
+        private set
+
+    fun processEvent(event: Event) {
+        when {
+            event.hasTextMessage() -> {
+                val msg = event.textMessage
+                _textMessages.add(
+                    ProcessedTextMessage(msg.agentId, msg.content, event.timestampMs)
+                )
+            }
+            event.hasBitmapPayload() -> {
+                val payload = event.bitmapPayload
+                cache.put(payload.cacheKey, payload.imageData.toByteArray())
+            }
+            event.hasDisplayCommand() -> {
+                currentDisplayKey = event.displayCommand.cacheKey
+            }
+            event.hasWatchdogTimeout() -> {
+                val wt = event.watchdogTimeout
+                _alerts.add(
+                    ProcessedAlert(
+                        AlertType.WATCHDOG_TIMEOUT,
+                        "Agent ${wt.agentId} unresponsive for ${wt.silentDurationMs}ms",
+                        event.timestampMs
+                    )
+                )
+            }
+            event.hasInputDeliveryFailure() -> {
+                val failure = event.inputDeliveryFailure
+                _alerts.add(
+                    ProcessedAlert(
+                        AlertType.INPUT_DELIVERY_FAILURE,
+                        "Failed to deliver '${failure.attemptedInput}' to ${failure.targetAgentId}",
+                        event.timestampMs
+                    )
+                )
+            }
+        }
+    }
+
+    fun processEvents(events: List<Event>) {
+        events.forEach { processEvent(it) }
+    }
+}
+
+data class ProcessedTextMessage(
+    val agentId: String,
+    val content: String,
+    val timestampMs: Long
+)
+
+data class ProcessedAlert(
+    val type: AlertType,
+    val message: String,
+    val timestampMs: Long
+)
+
+enum class AlertType {
+    WATCHDOG_TIMEOUT,
+    INPUT_DELIVERY_FAILURE
+}

--- a/android/app/src/test/kotlin/com/vanpilot/auto/cache/BitmapCacheTest.kt
+++ b/android/app/src/test/kotlin/com/vanpilot/auto/cache/BitmapCacheTest.kt
@@ -1,0 +1,117 @@
+package com.vanpilot.auto.cache
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class BitmapCacheTest {
+
+    private lateinit var cache: BitmapCache
+
+    @Before
+    fun setUp() {
+        cache = BitmapCache(maxSize = 4)
+    }
+
+    @Test
+    fun initialState_isEmpty() {
+        assertThat(cache.size()).isEqualTo(0)
+        assertThat(cache.keys()).isEmpty()
+    }
+
+    @Test
+    fun put_thenGet_returnsData() {
+        val data = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47) // PNG magic
+        cache.put("0xDEAD", data)
+        assertThat(cache.get("0xDEAD")).isEqualTo(data)
+    }
+
+    @Test
+    fun get_missingKey_returnsNull() {
+        assertThat(cache.get("nonexistent")).isNull()
+    }
+
+    @Test
+    fun contains_presentKey_returnsTrue() {
+        cache.put("0xBEEF", byteArrayOf(1, 2, 3))
+        assertThat(cache.contains("0xBEEF")).isTrue()
+    }
+
+    @Test
+    fun contains_missingKey_returnsFalse() {
+        assertThat(cache.contains("0xBEEF")).isFalse()
+    }
+
+    @Test
+    fun keys_returnsAllKeys() {
+        cache.put("a", byteArrayOf(1))
+        cache.put("b", byteArrayOf(2))
+        cache.put("c", byteArrayOf(3))
+        assertThat(cache.keys()).containsExactly("a", "b", "c")
+    }
+
+    @Test
+    fun remove_existingKey_returnsData() {
+        val data = byteArrayOf(1, 2, 3)
+        cache.put("key", data)
+        assertThat(cache.remove("key")).isEqualTo(data)
+        assertThat(cache.contains("key")).isFalse()
+    }
+
+    @Test
+    fun remove_missingKey_returnsNull() {
+        assertThat(cache.remove("nonexistent")).isNull()
+    }
+
+    @Test
+    fun eviction_removesOldestWhenFull() {
+        // maxSize is 4
+        cache.put("a", byteArrayOf(1))
+        cache.put("b", byteArrayOf(2))
+        cache.put("c", byteArrayOf(3))
+        cache.put("d", byteArrayOf(4))
+        assertThat(cache.size()).isEqualTo(4)
+
+        // Adding a 5th entry should evict "a" (oldest)
+        cache.put("e", byteArrayOf(5))
+        assertThat(cache.size()).isEqualTo(4)
+        assertThat(cache.contains("a")).isFalse()
+        assertThat(cache.contains("e")).isTrue()
+    }
+
+    @Test
+    fun eviction_accessOrderPromotesEntry() {
+        cache.put("a", byteArrayOf(1))
+        cache.put("b", byteArrayOf(2))
+        cache.put("c", byteArrayOf(3))
+        cache.put("d", byteArrayOf(4))
+
+        // Access "a" to promote it in LRU order
+        cache.get("a")
+
+        // Adding a 5th entry should evict "b" (now oldest), not "a"
+        cache.put("e", byteArrayOf(5))
+        assertThat(cache.contains("a")).isTrue()
+        assertThat(cache.contains("b")).isFalse()
+    }
+
+    @Test
+    fun put_overwritesExistingKey() {
+        cache.put("key", byteArrayOf(1))
+        cache.put("key", byteArrayOf(2))
+        assertThat(cache.get("key")).isEqualTo(byteArrayOf(2))
+        assertThat(cache.size()).isEqualTo(1)
+    }
+
+    @Test
+    fun size_tracksInsertionsAndRemovals() {
+        cache.put("a", byteArrayOf(1))
+        cache.put("b", byteArrayOf(2))
+        assertThat(cache.size()).isEqualTo(2)
+        cache.remove("a")
+        assertThat(cache.size()).isEqualTo(1)
+    }
+}

--- a/android/app/src/test/kotlin/com/vanpilot/auto/grpc/AndroidAppServiceImplTest.kt
+++ b/android/app/src/test/kotlin/com/vanpilot/auto/grpc/AndroidAppServiceImplTest.kt
@@ -1,0 +1,148 @@
+package com.vanpilot.auto.grpc
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.ByteString
+import com.vanpilot.auto.cache.BitmapCache
+import com.vanpilot.proto.v1.AndroidAppServiceGrpc
+import com.vanpilot.proto.v1.GetCurrentDisplayRequest
+import com.vanpilot.proto.v1.QueryCacheRequest
+import com.vanpilot.proto.v1.RequestScreenshotRequest
+import io.grpc.ManagedChannel
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
+import io.grpc.Server
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class AndroidAppServiceImplTest {
+
+    private lateinit var serverName: String
+    private lateinit var server: Server
+    private lateinit var channel: ManagedChannel
+    private lateinit var stub: AndroidAppServiceGrpc.AndroidAppServiceBlockingStub
+    private lateinit var cache: BitmapCache
+
+    private var currentDisplayKey: String? = null
+    private var screenshotData: ByteArray? = null
+
+    @Before
+    fun setUp() {
+        cache = BitmapCache(maxSize = 16)
+        currentDisplayKey = null
+        screenshotData = null
+
+        val service = AndroidAppServiceImpl(
+            cache = cache,
+            getCurrentDisplayKey = { currentDisplayKey },
+            captureScreenshot = { screenshotData }
+        )
+
+        serverName = InProcessServerBuilder.generateName()
+        server = InProcessServerBuilder.forName(serverName)
+            .directExecutor()
+            .addService(service)
+            .build()
+            .start()
+        channel = InProcessChannelBuilder.forName(serverName)
+            .directExecutor()
+            .build()
+        stub = AndroidAppServiceGrpc.newBlockingStub(channel)
+    }
+
+    @After
+    fun tearDown() {
+        channel.shutdownNow()
+        server.shutdownNow()
+    }
+
+    @Test
+    fun getCurrentDisplay_noDisplay_returnsEmptyKey() {
+        currentDisplayKey = null
+
+        val response = stub.getCurrentDisplay(GetCurrentDisplayRequest.getDefaultInstance())
+
+        assertThat(response.currentCacheKey).isEmpty()
+    }
+
+    @Test
+    fun getCurrentDisplay_withDisplay_returnsCacheKey() {
+        currentDisplayKey = "0xDEAD"
+
+        val response = stub.getCurrentDisplay(GetCurrentDisplayRequest.getDefaultInstance())
+
+        assertThat(response.currentCacheKey).isEqualTo("0xDEAD")
+    }
+
+    @Test
+    fun requestScreenshot_noScreenshot_returnsEmptyBytes() {
+        screenshotData = null
+
+        val response = stub.requestScreenshot(RequestScreenshotRequest.getDefaultInstance())
+
+        assertThat(response.screenshot).isEqualTo(ByteString.EMPTY)
+    }
+
+    @Test
+    fun requestScreenshot_withScreenshot_returnsPngData() {
+        val pngData = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+        screenshotData = pngData
+
+        val response = stub.requestScreenshot(RequestScreenshotRequest.getDefaultInstance())
+
+        assertThat(response.screenshot.toByteArray()).isEqualTo(pngData)
+    }
+
+    @Test
+    fun queryCache_emptyRequest_returnsAllKeys() {
+        cache.put("a", byteArrayOf(1))
+        cache.put("b", byteArrayOf(2))
+        cache.put("c", byteArrayOf(3))
+
+        val response = stub.queryCache(QueryCacheRequest.getDefaultInstance())
+
+        assertThat(response.presentKeysList).containsExactly("a", "b", "c")
+        assertThat(response.missingKeysList).isEmpty()
+    }
+
+    @Test
+    fun queryCache_specificKeys_partitionsCorrectly() {
+        cache.put("a", byteArrayOf(1))
+        cache.put("c", byteArrayOf(3))
+
+        val request = QueryCacheRequest.newBuilder()
+            .addKeys("a")
+            .addKeys("b")
+            .addKeys("c")
+            .build()
+
+        val response = stub.queryCache(request)
+
+        assertThat(response.presentKeysList).containsExactly("a", "c")
+        assertThat(response.missingKeysList).containsExactly("b")
+    }
+
+    @Test
+    fun queryCache_allMissing_returnsAllAsMissing() {
+        val request = QueryCacheRequest.newBuilder()
+            .addKeys("x")
+            .addKeys("y")
+            .build()
+
+        val response = stub.queryCache(request)
+
+        assertThat(response.presentKeysList).isEmpty()
+        assertThat(response.missingKeysList).containsExactly("x", "y")
+    }
+
+    @Test
+    fun queryCache_emptyCache_emptyRequest_returnsNothing() {
+        val response = stub.queryCache(QueryCacheRequest.getDefaultInstance())
+
+        assertThat(response.presentKeysList).isEmpty()
+        assertThat(response.missingKeysList).isEmpty()
+    }
+}

--- a/android/app/src/test/kotlin/com/vanpilot/auto/grpc/SyncServiceClientTest.kt
+++ b/android/app/src/test/kotlin/com/vanpilot/auto/grpc/SyncServiceClientTest.kt
@@ -1,0 +1,198 @@
+package com.vanpilot.auto.grpc
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.ByteString
+import com.vanpilot.proto.v1.BitmapPayload
+import com.vanpilot.proto.v1.Event
+import com.vanpilot.proto.v1.GetBitmapRequest
+import com.vanpilot.proto.v1.GetBitmapResponse
+import com.vanpilot.proto.v1.GetEventsRequest
+import com.vanpilot.proto.v1.GetEventsResponse
+import com.vanpilot.proto.v1.SendUserInputRequest
+import com.vanpilot.proto.v1.SendUserInputResponse
+import com.vanpilot.proto.v1.SyncServiceGrpc
+import com.vanpilot.proto.v1.TextMessage
+import io.grpc.ManagedChannel
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
+import io.grpc.stub.StreamObserver
+import io.grpc.Server
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class SyncServiceClientTest {
+
+    private lateinit var serverName: String
+    private lateinit var server: Server
+    private lateinit var channel: ManagedChannel
+    private lateinit var client: SyncServiceClient
+
+    private val fakeService = FakeSyncService()
+
+    @Before
+    fun setUp() {
+        serverName = InProcessServerBuilder.generateName()
+        server = InProcessServerBuilder.forName(serverName)
+            .directExecutor()
+            .addService(fakeService)
+            .build()
+            .start()
+        channel = InProcessChannelBuilder.forName(serverName)
+            .directExecutor()
+            .build()
+        client = SyncServiceClient(channel)
+    }
+
+    @After
+    fun tearDown() {
+        client.shutdown()
+        server.shutdownNow()
+    }
+
+    @Test
+    fun getEvents_returnsEventsFromServer() {
+        fakeService.eventsToReturn = listOf(
+            Event.newBuilder()
+                .setTimestampMs(1000)
+                .setTextMessage(
+                    TextMessage.newBuilder()
+                        .setAgentId("lead")
+                        .setContent("Hello")
+                )
+                .build(),
+            Event.newBuilder()
+                .setTimestampMs(2000)
+                .setTextMessage(
+                    TextMessage.newBuilder()
+                        .setAgentId("lead")
+                        .setContent("World")
+                )
+                .build()
+        )
+
+        val response = client.getEvents(sinceTimestampMs = 0, maxCount = 10)
+
+        assertThat(response.eventsList).hasSize(2)
+        assertThat(response.eventsList[0].textMessage.content).isEqualTo("Hello")
+        assertThat(response.eventsList[1].textMessage.content).isEqualTo("World")
+    }
+
+    @Test
+    fun getEvents_passesSinceTimestampAndMaxCount() {
+        client.getEvents(sinceTimestampMs = 5000, maxCount = 3)
+
+        assertThat(fakeService.lastGetEventsRequest?.sinceTimestampMs).isEqualTo(5000)
+        assertThat(fakeService.lastGetEventsRequest?.maxCount).isEqualTo(3)
+    }
+
+    @Test
+    fun getEvents_emptyResponse() {
+        fakeService.eventsToReturn = emptyList()
+
+        val response = client.getEvents(sinceTimestampMs = 0, maxCount = 10)
+
+        assertThat(response.eventsList).isEmpty()
+    }
+
+    @Test
+    fun sendUserInput_returnsAccepted() {
+        fakeService.acceptInput = true
+
+        val response = client.sendUserInput(text = "deploy the app", targetAgentId = "lead")
+
+        assertThat(response.accepted).isTrue()
+    }
+
+    @Test
+    fun sendUserInput_passesTextAndTargetAgent() {
+        client.sendUserInput(text = "run tests", targetAgentId = "researcher")
+
+        assertThat(fakeService.lastSendUserInputRequest?.text).isEqualTo("run tests")
+        assertThat(fakeService.lastSendUserInputRequest?.targetAgentId).isEqualTo("researcher")
+    }
+
+    @Test
+    fun sendUserInput_defaultTargetAgent() {
+        client.sendUserInput(text = "hello")
+
+        assertThat(fakeService.lastSendUserInputRequest?.targetAgentId).isEqualTo("lead")
+    }
+
+    @Test
+    fun getBitmap_returnsBitmapPayload() {
+        val pngData = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47)
+        fakeService.bitmapToReturn = BitmapPayload.newBuilder()
+            .setCacheKey("0xCAFE")
+            .setImageData(ByteString.copyFrom(pngData))
+            .setWidthPx(800)
+            .setHeightPx(480)
+            .build()
+
+        val response = client.getBitmap(cacheKey = "0xCAFE")
+
+        assertThat(response.bitmap.cacheKey).isEqualTo("0xCAFE")
+        assertThat(response.bitmap.imageData.toByteArray()).isEqualTo(pngData)
+        assertThat(response.bitmap.widthPx).isEqualTo(800)
+        assertThat(response.bitmap.heightPx).isEqualTo(480)
+    }
+
+    @Test
+    fun getBitmap_passesCacheKey() {
+        client.getBitmap(cacheKey = "0xDEAD")
+
+        assertThat(fakeService.lastGetBitmapRequest?.cacheKey).isEqualTo("0xDEAD")
+    }
+
+    /**
+     * Fake SyncService implementation for testing the client.
+     */
+    private class FakeSyncService : SyncServiceGrpc.SyncServiceImplBase() {
+        var eventsToReturn: List<Event> = emptyList()
+        var acceptInput: Boolean = true
+        var bitmapToReturn: BitmapPayload = BitmapPayload.getDefaultInstance()
+
+        var lastGetEventsRequest: GetEventsRequest? = null
+        var lastSendUserInputRequest: SendUserInputRequest? = null
+        var lastGetBitmapRequest: GetBitmapRequest? = null
+
+        override fun getEvents(
+            request: GetEventsRequest,
+            responseObserver: StreamObserver<GetEventsResponse>
+        ) {
+            lastGetEventsRequest = request
+            val response = GetEventsResponse.newBuilder()
+                .addAllEvents(eventsToReturn)
+                .build()
+            responseObserver.onNext(response)
+            responseObserver.onCompleted()
+        }
+
+        override fun sendUserInput(
+            request: SendUserInputRequest,
+            responseObserver: StreamObserver<SendUserInputResponse>
+        ) {
+            lastSendUserInputRequest = request
+            val response = SendUserInputResponse.newBuilder()
+                .setAccepted(acceptInput)
+                .build()
+            responseObserver.onNext(response)
+            responseObserver.onCompleted()
+        }
+
+        override fun getBitmap(
+            request: GetBitmapRequest,
+            responseObserver: StreamObserver<GetBitmapResponse>
+        ) {
+            lastGetBitmapRequest = request
+            val response = GetBitmapResponse.newBuilder()
+                .setBitmap(bitmapToReturn)
+                .build()
+            responseObserver.onNext(response)
+            responseObserver.onCompleted()
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vanpilot/auto/sync/EventProcessorTest.kt
+++ b/android/app/src/test/kotlin/com/vanpilot/auto/sync/EventProcessorTest.kt
@@ -1,0 +1,179 @@
+package com.vanpilot.auto.sync
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.ByteString
+import com.vanpilot.auto.cache.BitmapCache
+import com.vanpilot.proto.v1.BitmapPayload
+import com.vanpilot.proto.v1.DisplayCommand
+import com.vanpilot.proto.v1.Event
+import com.vanpilot.proto.v1.InputDeliveryFailure
+import com.vanpilot.proto.v1.TextMessage
+import com.vanpilot.proto.v1.WatchdogTimeout
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class EventProcessorTest {
+
+    private lateinit var cache: BitmapCache
+    private lateinit var processor: EventProcessor
+
+    @Before
+    fun setUp() {
+        cache = BitmapCache(maxSize = 16)
+        processor = EventProcessor(cache)
+    }
+
+    @Test
+    fun processTextMessage_storesMessage() {
+        val event = Event.newBuilder()
+            .setTimestampMs(1000)
+            .setTextMessage(
+                TextMessage.newBuilder()
+                    .setAgentId("lead")
+                    .setContent("Hello from agent")
+            )
+            .build()
+
+        processor.processEvent(event)
+
+        assertThat(processor.textMessages).hasSize(1)
+        val msg = processor.textMessages[0]
+        assertThat(msg.agentId).isEqualTo("lead")
+        assertThat(msg.content).isEqualTo("Hello from agent")
+        assertThat(msg.timestampMs).isEqualTo(1000)
+    }
+
+    @Test
+    fun processBitmapPayload_storesInCache() {
+        val pngData = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47)
+        val event = Event.newBuilder()
+            .setTimestampMs(2000)
+            .setBitmapPayload(
+                BitmapPayload.newBuilder()
+                    .setCacheKey("0xCAFE")
+                    .setImageData(ByteString.copyFrom(pngData))
+                    .setWidthPx(800)
+                    .setHeightPx(480)
+            )
+            .build()
+
+        processor.processEvent(event)
+
+        assertThat(cache.contains("0xCAFE")).isTrue()
+        assertThat(cache.get("0xCAFE")).isEqualTo(pngData)
+    }
+
+    @Test
+    fun processDisplayCommand_updatesCurrentDisplayKey() {
+        val event = Event.newBuilder()
+            .setTimestampMs(3000)
+            .setDisplayCommand(
+                DisplayCommand.newBuilder()
+                    .setCacheKey("0xBEEF")
+            )
+            .build()
+
+        processor.processEvent(event)
+
+        assertThat(processor.currentDisplayKey).isEqualTo("0xBEEF")
+    }
+
+    @Test
+    fun processDisplayCommand_overwritesPreviousKey() {
+        processor.processEvent(
+            Event.newBuilder()
+                .setTimestampMs(1000)
+                .setDisplayCommand(DisplayCommand.newBuilder().setCacheKey("first"))
+                .build()
+        )
+        processor.processEvent(
+            Event.newBuilder()
+                .setTimestampMs(2000)
+                .setDisplayCommand(DisplayCommand.newBuilder().setCacheKey("second"))
+                .build()
+        )
+
+        assertThat(processor.currentDisplayKey).isEqualTo("second")
+    }
+
+    @Test
+    fun processWatchdogTimeout_storesAlert() {
+        val event = Event.newBuilder()
+            .setTimestampMs(4000)
+            .setWatchdogTimeout(
+                WatchdogTimeout.newBuilder()
+                    .setAgentId("researcher")
+                    .setSilentDurationMs(30000)
+            )
+            .build()
+
+        processor.processEvent(event)
+
+        assertThat(processor.alerts).hasSize(1)
+        val alert = processor.alerts[0]
+        assertThat(alert.type).isEqualTo(AlertType.WATCHDOG_TIMEOUT)
+        assertThat(alert.message).contains("researcher")
+        assertThat(alert.message).contains("30000")
+        assertThat(alert.timestampMs).isEqualTo(4000)
+    }
+
+    @Test
+    fun processInputDeliveryFailure_storesAlert() {
+        val event = Event.newBuilder()
+            .setTimestampMs(5000)
+            .setInputDeliveryFailure(
+                InputDeliveryFailure.newBuilder()
+                    .setAttemptedInput("deploy the app")
+                    .setTargetAgentId("lead")
+            )
+            .build()
+
+        processor.processEvent(event)
+
+        assertThat(processor.alerts).hasSize(1)
+        val alert = processor.alerts[0]
+        assertThat(alert.type).isEqualTo(AlertType.INPUT_DELIVERY_FAILURE)
+        assertThat(alert.message).contains("deploy the app")
+        assertThat(alert.message).contains("lead")
+        assertThat(alert.timestampMs).isEqualTo(5000)
+    }
+
+    @Test
+    fun processEvents_handlesMultipleEvents() {
+        val events = listOf(
+            Event.newBuilder()
+                .setTimestampMs(1000)
+                .setTextMessage(
+                    TextMessage.newBuilder().setAgentId("lead").setContent("msg1")
+                )
+                .build(),
+            Event.newBuilder()
+                .setTimestampMs(2000)
+                .setTextMessage(
+                    TextMessage.newBuilder().setAgentId("lead").setContent("msg2")
+                )
+                .build(),
+            Event.newBuilder()
+                .setTimestampMs(3000)
+                .setDisplayCommand(
+                    DisplayCommand.newBuilder().setCacheKey("0xABC")
+                )
+                .build()
+        )
+
+        processor.processEvents(events)
+
+        assertThat(processor.textMessages).hasSize(2)
+        assertThat(processor.currentDisplayKey).isEqualTo("0xABC")
+    }
+
+    @Test
+    fun initialState_noMessagesOrAlerts() {
+        assertThat(processor.textMessages).isEmpty()
+        assertThat(processor.alerts).isEmpty()
+        assertThat(processor.currentDisplayKey).isNull()
+    }
+}


### PR DESCRIPTION
## Summary
- **BitmapCache**: Thread-safe LRU cache (`cache_key → PNG bytes`) with configurable max size and access-order eviction
- **SyncServiceClient**: gRPC client wrapping `SyncService` (GetEvents, SendUserInput, GetBitmap) using blocking stubs over a `ManagedChannel`
- **AndroidAppServiceImpl**: gRPC server implementing `AndroidAppService` (GetCurrentDisplay, RequestScreenshot, QueryCache) with functional injection for display state and screenshot capture
- **EventProcessor**: Processes 5 event types from `GetEventsResponse` into UI-consumable state (text messages, display commands, bitmap payloads, watchdog timeouts, input delivery failures)

## Architecture
- `grpc_lib` (`kt_jvm_library`) is separated from `vanpilot_lib` (`kt_android_library`) to avoid proto `.jar` dex issues in `android_binary`
- Tests use `InProcessServerBuilder` from `grpc-inprocess` — no network transport needed
- All proto/gRPC stubs use lite runtime for Android compatibility

## Tests written (TDD)
| Test | What it covers |
|---|---|
| `BitmapCacheTest` (11 tests) | LRU eviction, access-order promotion, put/get/remove/contains/keys/size |
| `SyncServiceClientTest` (7 tests) | getEvents, sendUserInput, getBitmap against a fake in-process SyncService |
| `AndroidAppServiceImplTest` (8 tests) | getCurrentDisplay, requestScreenshot, queryCache via in-process gRPC |
| `EventProcessorTest` (8 tests) | All 5 event types + batch processing + initial state |

## Test plan
- [x] `bazel test //android/...` — all 8 test targets pass (4 existing + 4 new)
- [x] `bazel build //android:vanpilot` — APK still builds
- [x] Reviewer: verify test coverage of all event types in EventProcessorTest
- [x] Reviewer: verify SyncServiceClient passes correct request params

🤖 Generated with [Claude Code](https://claude.com/claude-code)