### PR TITLE
Fix CI: mirror android.googlesource.com/dalvik to GitHub Releases

### DIFF
--- a/.bazel/downloader_config.cfg
+++ b/.bazel/downloader_config.cfg
@@ -1,0 +1,20 @@
+# Bazel URL rewrite rules for unreliable upstream dependencies.
+#
+# android.googlesource.com/platform/dalvik sporadically returns 403 on CI
+# (GitHub Actions macos-latest runners). Mirror the archive to GitHub Releases
+# so builds are not blocked by upstream availability.
+#
+# To add the mirror asset:
+#   curl -L "https://android.googlesource.com/platform/dalvik/+archive/5a81c499a569731e2395f7c8d13c0e0d4e17a2b6.tar.gz" \
+#        -o dalvik-5a81c499a569731e2395f7c8d13c0e0d4e17a2b6.tar.gz
+#   gh release create bazel-mirrors \
+#        --repo widdowson/vanpilot \
+#        --title "Bazel dependency mirrors" \
+#        --notes "Mirrors for Bazel deps with unreliable upstream hosting." \
+#        dalvik-5a81c499a569731e2395f7c8d13c0e0d4e17a2b6.tar.gz
+#
+# Rewrite rule: matches the dalvik archive URL and redirects to the GitHub
+# Releases mirror. The capture group ($1) preserves the filename
+# (hash + .tar.gz) so the mirrored filename is unambiguous.
+
+rewrite ^https://android\.googlesource\.com/platform/dalvik/\+archive/(.+\.tar\.gz)$ https://github.com/widdowson/vanpilot/releases/download/bazel-mirrors/dalvik-$1

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,6 @@
+# Mirror unreliable upstream deps (android.googlesource.com 403s on CI)
+build --experimental_downloader_config=.bazel/downloader_config.cfg
+
 # Java language level for Android compatibility
 build --java_language_version=11
 build --java_runtime_version=11


### PR DESCRIPTION
## Problem

`android.googlesource.com/platform/dalvik` sporadically returns `403 Forbidden` on GitHub Actions `macos-latest` runners, blocking all builds. This has been hitting every open PR for the entire session.

The failing fetch:
\`\`\`
https://android.googlesource.com/platform/dalvik/+archive/5a81c499a569731e2395f7c8d13c0e0d4e17a2b6.tar.gz
\`\`\`

## Fix

Adds a Bazel [downloader config](https://bazel.build/rules/lib/globals/repo#downloader_config) (`.bazel/downloader_config.cfg`) that rewrites the URL to a GitHub Releases mirror. Wired via `--experimental_downloader_config` in `.bazelrc`.

The rewrite is specific to this archive — no other downloads are affected.

## Required action before this PR makes CI green

Upload the mirror asset to a GitHub Release:

\`\`\`bash
# On your macOS host (where AOSP is accessible):
curl -L "https://android.googlesource.com/platform/dalvik/+archive/5a81c499a569731e2395f7c8d13c0e0d4e17a2b6.tar.gz" \
     -o dalvik-5a81c499a569731e2395f7c8d13c0e0d4e17a2b6.tar.gz

gh release create bazel-mirrors \
     --repo widdowson/vanpilot \
     --title "Bazel dependency mirrors" \
     --notes "Mirrors for Bazel deps with unreliable upstream hosting." \
     dalvik-5a81c499a569731e2395f7c8d13c0e0d4e17a2b6.tar.gz
\`\`\`

Once the asset is uploaded and this PR is merged, CI will always fetch from the mirror instead of `android.googlesource.com`. The mirrored file will have the URL:
\`https://github.com/widdowson/vanpilot/releases/download/bazel-mirrors/dalvik-5a81c499a569731e2395f7c8d13c0e0d4e17a2b6.tar.gz\`

## If you prefer GCP instead

Replace the rewrite target in `.bazel/downloader_config.cfg` with:
\`\`\`
rewrite ^https://android\.googlesource\.com/platform/dalvik/\+archive/(.+\.tar\.gz)$ https://storage.googleapis.com/<your-bucket>/bazel-mirrors/dalvik-$1
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)