### PR TITLE
ci: add test plan checklist gate for PRs

### DIFF
--- a/.github/workflows/test-plan-check.yml
+++ b/.github/workflows/test-plan-check.yml
@@ -1,0 +1,22 @@
+name: Test plan
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: All test plan items checked
+        run: |
+          UNCHECKED=$(echo "$BODY" | grep -c '^\s*- \[ \]' || true)
+          if [ "$UNCHECKED" -gt 0 ]; then
+            echo "::error::$UNCHECKED unchecked test plan item(s):"
+            echo "$BODY" | grep '^\s*- \[ \]'
+            exit 1
+          fi
+          echo "All test plan items checked (or no checklist found)."
+        env:
+          BODY: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
## Summary

- Adds a lightweight GitHub Actions workflow that checks all `- [ ]` items in the PR body are checked off before allowing merge
- Runs on `ubuntu-latest` in ~5 seconds (no checkout needed — just parses the PR body)
- Triggers on PR open, edit, and sync events so it re-evaluates when the body is updated

## Next step

After merging, add **Test plan / check** as a required status check in branch protection settings for `main`.

## Test plan

- [x] Workflow file is valid YAML with correct trigger events
- [x] PRs with unchecked items will fail the check
- [x] PRs with all items checked (or no checklist) will pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)