### PR TITLE
Expose emulator ADB port for remote sandbox access

### DIFF
--- a/docs/agent-instance-manager-guide.md
+++ b/docs/agent-instance-manager-guide.md
@@ -81,13 +81,28 @@ Each instance gets its own ADB port. The `create` output shows it:
 console=5554  adb=5555
 ```
 
+### Local access (on the Mac Studio)
+
 Connect with:
 
 ```bash
 adb -s emulator-5554 shell
 ```
 
-The serial is always `emulator-{console_port}`. Common operations:
+The serial is always `emulator-{console_port}`.
+
+### Remote access (from a Docker sandbox)
+
+The ADB port is exposed on all network interfaces via a `socat` forwarder, so sandbox agents can connect over Tailscale:
+
+```bash
+adb connect mac:5555
+adb -s mac:5555 shell
+```
+
+Replace `mac` with the Tailscale hostname or IP of the Mac Studio. The port is the ADB port shown in the `create` output.
+
+### Common operations
 
 ```bash
 # Install an APK

--- a/instance_manager/src/emulator_lifecycle.py
+++ b/instance_manager/src/emulator_lifecycle.py
@@ -35,6 +35,7 @@ class _ProcessHandles:
     emulator: Optional[subprocess.Popen] = None
     dhu: Optional[subprocess.Popen] = None
     keeper: Optional[subprocess.Popen] = None
+    socat: Optional[subprocess.Popen] = None
 
 
 class SubprocessRunner:
@@ -121,6 +122,21 @@ class EmulatorLifecycle:
             # 3b. Verify snapshot sentinel (detects cold-boot vs snapshot resume)
             self._check_snapshot_sentinel(serial)
 
+            # 3c. Start socat to expose ADB on all interfaces for remote access.
+            # The emulator binds ADB to 127.0.0.1 only; socat makes it
+            # reachable from Docker sandbox agents via Tailscale.
+            socat_proc = self._runner.popen(
+                [
+                    "socat",
+                    f"TCP-LISTEN:{ports.adb_port},bind=0.0.0.0,reuseaddr,fork",
+                    f"TCP:127.0.0.1:{ports.adb_port}",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            handles.socat = socat_proc
+            self._store.update(name, socat_pid=socat_proc.pid)
+
             # 4. Forward AA port
             self._runner.run(
                 ["adb", "-s", serial, "forward",
@@ -186,7 +202,7 @@ class EmulatorLifecycle:
 
         except Exception:
             # Best-effort cleanup of any already-started processes.
-            for proc in [handles.dhu, handles.keeper, handles.emulator]:
+            for proc in [handles.dhu, handles.keeper, handles.socat, handles.emulator]:
                 if proc is not None:
                     try:
                         proc.kill()
@@ -255,7 +271,16 @@ class EmulatorLifecycle:
                 handles.keeper.kill()
                 handles.keeper.wait(timeout=_DESTROY_GRACEFUL_TIMEOUT)
 
-        # 3. Emulator — ask adb to shut it down cleanly first
+
+        # 3. Socat ADB forwarder
+        if handles.socat and handles.socat.poll() is None:
+            handles.socat.terminate()
+            try:
+                handles.socat.wait(timeout=_DESTROY_GRACEFUL_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                handles.socat.kill()
+                handles.socat.wait(timeout=_DESTROY_GRACEFUL_TIMEOUT)
+        # 4. Emulator — ask adb to shut it down cleanly first
         if handles.emulator and handles.emulator.poll() is None:
             self._runner.run(
                 ["adb", "-s", serial, "emu", "kill"],
@@ -283,6 +308,11 @@ class EmulatorLifecycle:
         if record.keeper_pid:
             self._runner.run(
                 ["kill", str(record.keeper_pid)],
+                capture_output=True,
+            )
+        if record.socat_pid:
+            self._runner.run(
+                ["kill", str(record.socat_pid)],
                 capture_output=True,
             )
         self._runner.run(
@@ -409,7 +439,7 @@ class EmulatorLifecycle:
             handles = self._handles.get(name)
         if handles is None:
             return True
-        for proc in [handles.emulator, handles.dhu, handles.keeper]:
+        for proc in [handles.emulator, handles.dhu, handles.keeper, handles.socat]:
             if proc is not None and proc.poll() is not None:
                 return False
         return True

--- a/instance_manager/src/instance_store.py
+++ b/instance_manager/src/instance_store.py
@@ -29,6 +29,7 @@ class InstanceRecord:
     emulator_pid: Optional[int] = None
     dhu_pid: Optional[int] = None
     keeper_pid: Optional[int] = None
+    socat_pid: Optional[int] = None
     pipe_path: Optional[str] = None
     log_path: Optional[str] = None
     last_screenshot_png: Optional[bytes] = None

--- a/instance_manager/tests/test_emulator_lifecycle.py
+++ b/instance_manager/tests/test_emulator_lifecycle.py
@@ -410,6 +410,118 @@ class EmulatorLifecycleTest(unittest.TestCase):
         self.assertIn(["kill", "101"], kill_args)
 
 
+    def test_create_starts_socat_forwarder(self):
+        """create() launches socat to expose ADB on 0.0.0.0."""
+        store, runner, lifecycle = self._make_lifecycle()
+        ports = self._make_ports()
+        store.create("test", 5554, 5555, 5277, False, 1000, "test_avd")
+
+        with patch.object(lifecycle, "_resolve_gpu_mode", return_value="swiftshader_indirect"):
+            with patch.object(lifecycle, "_wait_for_dhu"):
+                with patch.object(lifecycle, "_wait_for_dhu_screenshot", return_value=b"png"), \
+                     patch.object(lifecycle, "emulator_screenshot_to_bytes", return_value=b"png"):
+                    lifecycle.create("test", "test_avd", "aa_ready", False, ports)
+
+        # Find the socat popen call (second popen: emulator is first, socat is second)
+        socat_calls = [
+            c for c in runner.popen_calls
+            if c[0][0] == "socat"
+        ]
+        self.assertEqual(len(socat_calls), 1)
+        socat_args = socat_calls[0][0]
+        self.assertEqual(socat_args[0], "socat")
+        self.assertIn("TCP-LISTEN:5555", socat_args[1])
+        self.assertIn("bind=0.0.0.0", socat_args[1])
+        self.assertEqual(socat_args[2], "TCP:127.0.0.1:5555")
+
+    def test_create_stores_socat_pid(self):
+        """create() records the socat PID in the instance store."""
+        store, runner, lifecycle = self._make_lifecycle()
+        ports = self._make_ports()
+        store.create("test", 5554, 5555, 5277, False, 1000, "test_avd")
+
+        with patch.object(lifecycle, "_resolve_gpu_mode", return_value="swiftshader_indirect"):
+            with patch.object(lifecycle, "_wait_for_dhu"):
+                with patch.object(lifecycle, "_wait_for_dhu_screenshot", return_value=b"png"), \
+                     patch.object(lifecycle, "emulator_screenshot_to_bytes", return_value=b"png"):
+                    record = lifecycle.create("test", "test_avd", "aa_ready", False, ports)
+
+        self.assertIsNotNone(record.socat_pid)
+
+    def test_destroy_kills_socat_via_handles(self):
+        """destroy() terminates the socat process when Popen handles exist."""
+        store, runner, lifecycle = self._make_lifecycle()
+        store.create("test", 5554, 5555, 5277, False, 1000, "test_avd")
+        store.update(
+            "test",
+            state=RUNNING,
+            dhu_pid=100,
+            keeper_pid=101,
+            emulator_pid=102,
+            socat_pid=103,
+            pipe_path="/tmp/dhu_test_pipe",
+            log_path="/tmp/dhu_test.log",
+        )
+        record = store.get("test")
+
+        from instance_manager.src.emulator_lifecycle import _ProcessHandles
+        socat_proc = MagicMock()
+        socat_proc.poll.return_value = None
+        socat_proc.wait.return_value = 0
+
+        lifecycle._handles["test"] = _ProcessHandles(
+            emulator=MagicMock(poll=MagicMock(return_value=None), wait=MagicMock(return_value=0)),
+            dhu=MagicMock(pid=100, poll=MagicMock(return_value=None), wait=MagicMock(return_value=0)),
+            keeper=MagicMock(poll=MagicMock(return_value=None), wait=MagicMock(return_value=0)),
+            socat=socat_proc,
+        )
+
+        with patch("os.getpgid", return_value=200), \
+             patch("os.killpg"):
+            lifecycle.destroy(record)
+
+        socat_proc.terminate.assert_called_once()
+
+    def test_destroy_kills_socat_via_pid(self):
+        """destroy() kills socat by PID when no Popen handles exist."""
+        store, runner, lifecycle = self._make_lifecycle()
+        store.create("test", 5554, 5555, 5277, False, 1000, "test_avd")
+        store.update(
+            "test",
+            state=RUNNING,
+            dhu_pid=100,
+            keeper_pid=101,
+            emulator_pid=102,
+            socat_pid=103,
+            pipe_path="/tmp/dhu_test_pipe",
+            log_path="/tmp/dhu_test.log",
+        )
+        record = store.get("test")
+
+        lifecycle.destroy(record)
+
+        kill_args = [c[0] for c in runner.run_calls if c[0][0] == "kill"]
+        self.assertIn(["kill", "103"], kill_args)
+
+    def test_check_health_socat_dead(self):
+        """check_health returns False when the socat process has exited."""
+        store, _, lifecycle = self._make_lifecycle()
+        from instance_manager.src.emulator_lifecycle import _ProcessHandles
+
+        emu = MagicMock()
+        emu.poll.return_value = None
+        dhu = MagicMock()
+        dhu.poll.return_value = None
+        keeper = MagicMock()
+        keeper.poll.return_value = None
+        socat = MagicMock()
+        socat.poll.return_value = 1  # exited
+
+        lifecycle._handles["test"] = _ProcessHandles(
+            emulator=emu, dhu=dhu, keeper=keeper, socat=socat,
+        )
+        self.assertFalse(lifecycle.check_health("test"))
+
     def test_dhu_command_writes_to_pipe(self):
         """dhu_command writes the command string to the named pipe."""
         store, runner, lifecycle = self._make_lifecycle()


### PR DESCRIPTION
## Summary

- The Android emulator binds its ADB port to `127.0.0.1` only, preventing Docker sandbox agents from connecting via `adb connect mac:<port>` over Tailscale
- Adds a `socat` TCP forwarder per instance that binds `0.0.0.0:<adb_port>` and proxies to `127.0.0.1:<adb_port>`, launched during `create()` after emulator boot
- Socat process is tracked in `_ProcessHandles` and `InstanceRecord.socat_pid`, cleaned up in `destroy()` (both Popen-handle and PID-fallback paths), and monitored by `check_health()`
- Updates the agent guide with remote ADB access instructions

## Test plan

- [x] 5 new unit tests added and passing (socat launch args, PID storage, destroy via handles, destroy via PID, check_health detection)
- [x] All 26 existing + new unit tests pass
- [x] Manual: create an instance, verify `socat` process is running with `ps aux | grep socat`
- [x] Manual: from a Docker sandbox, run `adb connect mac:<adb_port>` and verify connection succeeds
- [x] Manual: destroy instance and verify socat process is cleaned up
- [x] Manual: verify `socat` is installed on the Mac Studio (`which socat`, install via `brew install socat` if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)