### PR TITLE
feat: coordinate calibration MCP tool

### DIFF
--- a/mcp/src/calibrate.py
+++ b/mcp/src/calibrate.py
@@ -1,0 +1,173 @@
+"""Coordinate calibration for DHU screenshot-to-tap mapping.
+
+Agents see DHU screenshots (1920x1080) but the VanPilot app occupies only a
+portion of the display. This module generates a calibration pattern, detects
+it in a screenshot, and computes the coordinate transform.
+"""
+
+import io
+
+from PIL import Image
+
+# Marker size in pixels
+MARKER_SIZE = 50
+
+# Calibration colors
+MAGENTA = (255, 0, 255)
+RED = (255, 0, 0)
+GREEN = (0, 255, 0)
+BLUE = (0, 0, 255)
+YELLOW = (255, 255, 0)
+
+# Color distance threshold for marker detection
+_COLOR_THRESHOLD = 80
+
+
+def generate_calibration_pattern(width: int, height: int) -> bytes:
+    """Generate a calibration pattern PNG.
+
+    Creates an image with magenta background and four colored corner markers
+    (each 50x50px): red top-left, green top-right, blue bottom-left, yellow
+    bottom-right.
+
+    Args:
+        width: Pattern width in pixels.
+        height: Pattern height in pixels.
+
+    Returns:
+        Raw PNG bytes.
+    """
+    img = Image.new("RGB", (width, height), MAGENTA)
+
+    # Draw corner markers
+    _fill_rect(img, 0, 0, MARKER_SIZE, MARKER_SIZE, RED)
+    _fill_rect(img, width - MARKER_SIZE, 0, MARKER_SIZE, MARKER_SIZE, GREEN)
+    _fill_rect(img, 0, height - MARKER_SIZE, MARKER_SIZE, MARKER_SIZE, BLUE)
+    _fill_rect(img, width - MARKER_SIZE, height - MARKER_SIZE, MARKER_SIZE, MARKER_SIZE, YELLOW)
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def detect_calibration_markers(screenshot_png: bytes) -> dict:
+    """Detect calibration markers in a DHU screenshot.
+
+    Scans the screenshot for clusters of the four marker colors and returns
+    their center positions.
+
+    Args:
+        screenshot_png: Full DHU screenshot as PNG bytes (typically 1920x1080).
+
+    Returns:
+        Dict with marker center positions:
+        {"red_tl": (x, y), "green_tr": (x, y),
+         "blue_bl": (x, y), "yellow_br": (x, y)}
+    """
+    img = Image.open(io.BytesIO(screenshot_png)).convert("RGB")
+
+    markers = {
+        "red_tl": _find_marker_center(img, RED),
+        "green_tr": _find_marker_center(img, GREEN),
+        "blue_bl": _find_marker_center(img, BLUE),
+        "yellow_br": _find_marker_center(img, YELLOW),
+    }
+    return markers
+
+
+def compute_transform(markers: dict, pattern_size: tuple) -> dict:
+    """Compute the coordinate transform from app coordinates to DHU coordinates.
+
+    Args:
+        markers: Detected marker positions from detect_calibration_markers().
+        pattern_size: (width, height) of the original calibration pattern.
+
+    Returns:
+        Dict with transform parameters:
+        - app_rect: {left, top, right, bottom} of the app area in screenshot coords
+        - scale_x, scale_y: scale factors from pattern coords to screenshot coords
+        - offset_x, offset_y: offset of app area in screenshot
+        - usage: human-readable formula
+    """
+    pat_w, pat_h = pattern_size
+
+    # Marker centers are at (25, 25) from each corner in pattern coords.
+    # In screenshot coords, the markers tell us where those points are.
+    # So the app area extends 25 pixels beyond each marker center.
+    half_marker = MARKER_SIZE // 2
+
+    tl = markers["red_tl"]
+    tr = markers["green_tr"]
+    bl = markers["blue_bl"]
+    br = markers["yellow_br"]
+
+    # App rectangle in screenshot coordinates
+    left = round((tl[0] + bl[0]) / 2 - half_marker)
+    top = round((tl[1] + tr[1]) / 2 - half_marker)
+    right = round((tr[0] + br[0]) / 2 + half_marker)
+    bottom = round((bl[1] + br[1]) / 2 + half_marker)
+
+    # Displayed size in screenshot pixels
+    disp_w = right - left
+    disp_h = bottom - top
+
+    # Scale: how many screenshot pixels per pattern pixel
+    scale_x = disp_w / pat_w
+    scale_y = disp_h / pat_h
+
+    return {
+        "app_rect": {"left": left, "top": top, "right": right, "bottom": bottom},
+        "scale_x": round(scale_x, 4),
+        "scale_y": round(scale_y, 4),
+        "offset_x": left,
+        "offset_y": top,
+        "usage": "dhu_x = offset_x + app_x * scale_x",
+    }
+
+
+def _fill_rect(
+    img: Image.Image, x: int, y: int, w: int, h: int, color: tuple
+) -> None:
+    """Fill a rectangle in the image."""
+    for py in range(y, y + h):
+        for px in range(x, x + w):
+            img.putpixel((px, py), color)
+
+
+def _color_distance(c1: tuple, c2: tuple) -> float:
+    """Euclidean distance between two RGB colors."""
+    return sum((a - b) ** 2 for a, b in zip(c1, c2)) ** 0.5
+
+
+def _find_marker_center(img: Image.Image, target_color: tuple) -> tuple:
+    """Find the center of a marker region by scanning for matching pixels.
+
+    Uses a sampling strategy for performance: scan every 2nd pixel to find
+    the bounding box, then compute the center.
+    """
+    w, h = img.size
+    min_x, min_y = w, h
+    max_x, max_y = 0, 0
+    found = False
+
+    step = 2
+    for py in range(0, h, step):
+        for px in range(0, w, step):
+            pixel = img.getpixel((px, py))
+            if _color_distance(pixel, target_color) < _COLOR_THRESHOLD:
+                if px < min_x:
+                    min_x = px
+                if px > max_x:
+                    max_x = px
+                if py < min_y:
+                    min_y = py
+                if py > max_y:
+                    max_y = py
+                found = True
+
+    if not found:
+        raise ValueError(f"Marker color {target_color} not found in screenshot")
+
+    cx = (min_x + max_x) // 2
+    cy = (min_y + max_y) // 2
+    return (cx, cy)

--- a/mcp/src/handlers.py
+++ b/mcp/src/handlers.py
@@ -10,6 +10,7 @@ import time
 from typing import Callable, Optional
 
 from mcp.src.png_util import png_cache_key, make_teal_display
+from mcp.src.calibrate import generate_calibration_pattern
 
 # Module-level bitmap cache: cache_key -> raw PNG bytes
 _cache: dict[str, bytes] = {}
@@ -180,4 +181,41 @@ def handle_get_screenshot() -> dict:
 
     return {
         "screenshot": base64.b64encode(png_bytes).decode(),
+    }
+
+
+def handle_calibrate_display(
+    pattern_width: int = 1024, pattern_height: int = 600
+) -> dict:
+    """Handle the calibrate_display tool call.
+
+    Generates a calibration pattern, submits it to the bitmap cache, and
+    displays it. Returns the cache key and pattern dimensions so agents
+    can later capture a DHU screenshot and run marker detection.
+    """
+    pattern_png = generate_calibration_pattern(pattern_width, pattern_height)
+    image_b64 = base64.b64encode(pattern_png).decode()
+
+    submit_result = handle_submit_bitmap(image_data=image_b64)
+    cache_key = submit_result["cache_key"]
+
+    display_result = handle_display_bitmap(cache_key=cache_key)
+
+    return {
+        "success": display_result.get("success", False),
+        "cache_key": cache_key,
+        "pattern_width": pattern_width,
+        "pattern_height": pattern_height,
+        "marker_size": 50,
+        "marker_colors": {
+            "top_left": "red (#FF0000)",
+            "top_right": "green (#00FF00)",
+            "bottom_left": "blue (#0000FF)",
+            "bottom_right": "yellow (#FFFF00)",
+        },
+        "next_step": (
+            "Capture a DHU screenshot with get_screenshot, then use the "
+            "calibrate module's detect_calibration_markers() and "
+            "compute_transform() to get the coordinate mapping."
+        ),
     }

--- a/mcp/src/server.py
+++ b/mcp/src/server.py
@@ -19,6 +19,7 @@ from mcp.src.handlers import (
     handle_display_bitmap,
     handle_submit_bitmap,
     handle_get_screenshot,
+    handle_calibrate_display,
 )
 
 SERVER_INFO = {
@@ -33,6 +34,7 @@ _HANDLERS = {
     "display_bitmap": handle_display_bitmap,
     "submit_bitmap": handle_submit_bitmap,
     "get_screenshot": handle_get_screenshot,
+    "calibrate_display": handle_calibrate_display,
 }
 
 

--- a/mcp/src/tools.py
+++ b/mcp/src/tools.py
@@ -67,6 +67,30 @@ TOOL_DEFINITIONS = [
             "properties": {},
         },
     },
+    {
+        "name": "calibrate_display",
+        "description": (
+            "Run coordinate calibration to determine where the VanPilot app "
+            "appears within the DHU screenshot. Displays a calibration pattern "
+            "with colored corner markers, then returns the pattern info needed "
+            "to compute the app-to-DHU coordinate transform."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "pattern_width": {
+                    "type": "integer",
+                    "description": "Width of the calibration pattern in pixels. Default: 1024.",
+                    "default": 1024,
+                },
+                "pattern_height": {
+                    "type": "integer",
+                    "description": "Height of the calibration pattern in pixels. Default: 600.",
+                    "default": 600,
+                },
+            },
+        },
+    },
 ]
 
 

--- a/mcp/tests/test_calibrate.py
+++ b/mcp/tests/test_calibrate.py
@@ -1,0 +1,240 @@
+"""Tests for coordinate calibration module.
+
+TDD: These tests are written BEFORE the implementation in mcp/src/calibrate.py.
+"""
+
+import io
+import unittest
+
+from PIL import Image
+
+
+class PatternGeneratorTest(unittest.TestCase):
+    """Tests for generate_calibration_pattern()."""
+
+    def setUp(self):
+        from mcp.src.calibrate import generate_calibration_pattern
+
+        self.generate = generate_calibration_pattern
+
+    def test_returns_valid_png(self):
+        data = self.generate(1024, 600)
+        # PNG signature check
+        self.assertTrue(data[:8] == b"\x89PNG\r\n\x1a\n")
+        # Should be loadable by Pillow
+        img = Image.open(io.BytesIO(data))
+        self.assertEqual(img.format, "PNG")
+
+    def test_correct_dimensions(self):
+        data = self.generate(1024, 600)
+        img = Image.open(io.BytesIO(data))
+        self.assertEqual(img.size, (1024, 600))
+
+    def test_magenta_background(self):
+        data = self.generate(1024, 600)
+        img = Image.open(io.BytesIO(data)).convert("RGB")
+        # Center pixel should be magenta
+        cx, cy = 512, 300
+        self.assertEqual(img.getpixel((cx, cy)), (255, 0, 255))
+
+    def test_top_left_marker_red(self):
+        data = self.generate(1024, 600)
+        img = Image.open(io.BytesIO(data)).convert("RGB")
+        # Inside the 50x50 top-left marker
+        self.assertEqual(img.getpixel((10, 10)), (255, 0, 0))
+
+    def test_top_right_marker_green(self):
+        data = self.generate(1024, 600)
+        img = Image.open(io.BytesIO(data)).convert("RGB")
+        self.assertEqual(img.getpixel((1024 - 10, 10)), (0, 255, 0))
+
+    def test_bottom_left_marker_blue(self):
+        data = self.generate(1024, 600)
+        img = Image.open(io.BytesIO(data)).convert("RGB")
+        self.assertEqual(img.getpixel((10, 600 - 10)), (0, 0, 255))
+
+    def test_bottom_right_marker_yellow(self):
+        data = self.generate(1024, 600)
+        img = Image.open(io.BytesIO(data)).convert("RGB")
+        self.assertEqual(img.getpixel((1024 - 10, 600 - 10)), (255, 255, 0))
+
+    def test_marker_boundaries(self):
+        """Pixels just outside markers should be magenta."""
+        data = self.generate(1024, 600)
+        img = Image.open(io.BytesIO(data)).convert("RGB")
+        magenta = (255, 0, 255)
+        # Just outside top-left marker
+        self.assertEqual(img.getpixel((51, 25)), magenta)
+        self.assertEqual(img.getpixel((25, 51)), magenta)
+
+    def test_different_dimensions(self):
+        data = self.generate(800, 480)
+        img = Image.open(io.BytesIO(data)).convert("RGB")
+        self.assertEqual(img.size, (800, 480))
+        # Markers still at corners
+        self.assertEqual(img.getpixel((10, 10)), (255, 0, 0))
+        self.assertEqual(img.getpixel((800 - 10, 10)), (0, 255, 0))
+        self.assertEqual(img.getpixel((10, 480 - 10)), (0, 0, 255))
+        self.assertEqual(img.getpixel((800 - 10, 480 - 10)), (255, 255, 0))
+
+
+class PatternDetectorTest(unittest.TestCase):
+    """Tests for detect_calibration_markers()."""
+
+    def setUp(self):
+        from mcp.src.calibrate import (
+            generate_calibration_pattern,
+            detect_calibration_markers,
+        )
+
+        self.generate = generate_calibration_pattern
+        self.detect = detect_calibration_markers
+
+    def _composite_pattern_on_screenshot(self, offset_x, offset_y, pat_w, pat_h):
+        """Create a 1920x1080 screenshot with calibration pattern composited at offset."""
+        screenshot = Image.new("RGB", (1920, 1080), (0, 0, 0))
+        pattern_data = self.generate(pat_w, pat_h)
+        pattern_img = Image.open(io.BytesIO(pattern_data))
+        screenshot.paste(pattern_img, (offset_x, offset_y))
+        buf = io.BytesIO()
+        screenshot.save(buf, format="PNG")
+        return buf.getvalue()
+
+    def test_pattern_at_right_half(self):
+        """Pattern occupying right half: x=960, y=0, 960x1080."""
+        screenshot_png = self._composite_pattern_on_screenshot(960, 0, 960, 1080)
+        markers = self.detect(screenshot_png)
+        # Top-left red marker center should be near (960 + 25, 25)
+        self.assertAlmostEqual(markers["red_tl"][0], 960 + 25, delta=2)
+        self.assertAlmostEqual(markers["red_tl"][1], 25, delta=2)
+        # Top-right green marker center near (1920 - 25, 25)
+        self.assertAlmostEqual(markers["green_tr"][0], 1920 - 25, delta=2)
+        self.assertAlmostEqual(markers["green_tr"][1], 25, delta=2)
+        # Bottom-left blue marker center near (960 + 25, 1080 - 25)
+        self.assertAlmostEqual(markers["blue_bl"][0], 960 + 25, delta=2)
+        self.assertAlmostEqual(markers["blue_bl"][1], 1080 - 25, delta=2)
+        # Bottom-right yellow marker center near (1920 - 25, 1080 - 25)
+        self.assertAlmostEqual(markers["yellow_br"][0], 1920 - 25, delta=2)
+        self.assertAlmostEqual(markers["yellow_br"][1], 1080 - 25, delta=2)
+
+    def test_pattern_full_screen(self):
+        """Pattern filling entire 1920x1080."""
+        screenshot_png = self._composite_pattern_on_screenshot(0, 0, 1920, 1080)
+        markers = self.detect(screenshot_png)
+        self.assertAlmostEqual(markers["red_tl"][0], 25, delta=2)
+        self.assertAlmostEqual(markers["red_tl"][1], 25, delta=2)
+        self.assertAlmostEqual(markers["yellow_br"][0], 1920 - 25, delta=2)
+        self.assertAlmostEqual(markers["yellow_br"][1], 1080 - 25, delta=2)
+
+    def test_pattern_at_quarter_screen(self):
+        """Pattern at bottom-right quarter: x=960, y=540, 960x540."""
+        screenshot_png = self._composite_pattern_on_screenshot(960, 540, 960, 540)
+        markers = self.detect(screenshot_png)
+        self.assertAlmostEqual(markers["red_tl"][0], 960 + 25, delta=2)
+        self.assertAlmostEqual(markers["red_tl"][1], 540 + 25, delta=2)
+        self.assertAlmostEqual(markers["yellow_br"][0], 1920 - 25, delta=2)
+        self.assertAlmostEqual(markers["yellow_br"][1], 1080 - 25, delta=2)
+
+    def test_returns_all_four_markers(self):
+        screenshot_png = self._composite_pattern_on_screenshot(0, 0, 1920, 1080)
+        markers = self.detect(screenshot_png)
+        self.assertIn("red_tl", markers)
+        self.assertIn("green_tr", markers)
+        self.assertIn("blue_bl", markers)
+        self.assertIn("yellow_br", markers)
+
+    def test_marker_values_are_tuples(self):
+        screenshot_png = self._composite_pattern_on_screenshot(0, 0, 1920, 1080)
+        markers = self.detect(screenshot_png)
+        for key in ("red_tl", "green_tr", "blue_bl", "yellow_br"):
+            self.assertIsInstance(markers[key], tuple)
+            self.assertEqual(len(markers[key]), 2)
+
+
+class TransformCalculatorTest(unittest.TestCase):
+    """Tests for compute_transform()."""
+
+    def setUp(self):
+        from mcp.src.calibrate import compute_transform
+
+        self.compute = compute_transform
+
+    def test_right_half_transform(self):
+        """Pattern at right half (960-1920, 0-1080), original 1024x600."""
+        markers = {
+            "red_tl": (960 + 25, 25),
+            "green_tr": (1920 - 25, 25),
+            "blue_bl": (960 + 25, 1080 - 25),
+            "yellow_br": (1920 - 25, 1080 - 25),
+        }
+        result = self.compute(markers, (1024, 600))
+        # App rect
+        self.assertAlmostEqual(result["app_rect"]["left"], 960, delta=5)
+        self.assertAlmostEqual(result["app_rect"]["top"], 0, delta=5)
+        self.assertAlmostEqual(result["app_rect"]["right"], 1920, delta=5)
+        self.assertAlmostEqual(result["app_rect"]["bottom"], 1080, delta=5)
+        # Offset
+        self.assertAlmostEqual(result["offset_x"], 960, delta=5)
+        self.assertAlmostEqual(result["offset_y"], 0, delta=5)
+        # Scale: displayed is 960px wide, pattern is 1024px wide
+        expected_scale_x = 960.0 / 1024.0
+        self.assertAlmostEqual(result["scale_x"], expected_scale_x, places=2)
+        expected_scale_y = 1080.0 / 600.0
+        self.assertAlmostEqual(result["scale_y"], expected_scale_y, places=2)
+
+    def test_full_screen_transform(self):
+        """Pattern fills entire 1920x1080, original 1920x1080."""
+        markers = {
+            "red_tl": (25, 25),
+            "green_tr": (1920 - 25, 25),
+            "blue_bl": (25, 1080 - 25),
+            "yellow_br": (1920 - 25, 1080 - 25),
+        }
+        result = self.compute(markers, (1920, 1080))
+        self.assertAlmostEqual(result["offset_x"], 0, delta=5)
+        self.assertAlmostEqual(result["offset_y"], 0, delta=5)
+        self.assertAlmostEqual(result["scale_x"], 1.0, places=2)
+        self.assertAlmostEqual(result["scale_y"], 1.0, places=2)
+
+    def test_quarter_screen_transform(self):
+        """Pattern at bottom-right quarter (960-1920, 540-1080), original 960x540."""
+        markers = {
+            "red_tl": (960 + 25, 540 + 25),
+            "green_tr": (1920 - 25, 540 + 25),
+            "blue_bl": (960 + 25, 1080 - 25),
+            "yellow_br": (1920 - 25, 1080 - 25),
+        }
+        result = self.compute(markers, (960, 540))
+        self.assertAlmostEqual(result["offset_x"], 960, delta=5)
+        self.assertAlmostEqual(result["offset_y"], 540, delta=5)
+        self.assertAlmostEqual(result["scale_x"], 1.0, places=2)
+        self.assertAlmostEqual(result["scale_y"], 1.0, places=2)
+
+    def test_result_has_usage_hint(self):
+        markers = {
+            "red_tl": (25, 25),
+            "green_tr": (1895, 25),
+            "blue_bl": (25, 1055),
+            "yellow_br": (1895, 1055),
+        }
+        result = self.compute(markers, (1920, 1080))
+        self.assertIn("usage", result)
+        self.assertIsInstance(result["usage"], str)
+
+    def test_result_has_app_rect(self):
+        markers = {
+            "red_tl": (25, 25),
+            "green_tr": (1895, 25),
+            "blue_bl": (25, 1055),
+            "yellow_br": (1895, 1055),
+        }
+        result = self.compute(markers, (1920, 1080))
+        rect = result["app_rect"]
+        self.assertIn("left", rect)
+        self.assertIn("top", rect)
+        self.assertIn("right", rect)
+        self.assertIn("bottom", rect)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp/tests/test_server.py
+++ b/mcp/tests/test_server.py
@@ -65,11 +65,11 @@ class ToolsListTest(unittest.TestCase):
         response = handle_request(request)
         self.assertEqual(response["id"], 2)
         tools = response["result"]["tools"]
-        self.assertEqual(len(tools), 3)
+        self.assertEqual(len(tools), 4)
         tool_names = {t["name"] for t in tools}
         self.assertEqual(
             tool_names,
-            {"display_bitmap", "submit_bitmap", "get_screenshot"},
+            {"display_bitmap", "submit_bitmap", "get_screenshot", "calibrate_display"},
         )
 
 

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -13,7 +13,7 @@ class ToolDefinitionsTest(unittest.TestCase):
     """Tests that tool definitions are well-formed and complete."""
 
     def test_three_tools_defined(self):
-        self.assertEqual(len(TOOL_DEFINITIONS), 3)
+        self.assertEqual(len(TOOL_DEFINITIONS), 4)
 
     def test_display_bitmap_definition(self):
         tool = get_tool_by_name("display_bitmap")


### PR DESCRIPTION
## Summary
- Adds `calibrate_display` MCP tool for mapping DHU screenshot coordinates to app tap coordinates
- New `mcp/src/calibrate.py` module with pattern generator (magenta background + 4 colored corner markers), marker detector (scans screenshots for marker colors), and transform calculator (computes scale/offset)
- 19 new tests in `mcp/tests/test_calibrate.py` (TDD: written before implementation)
- MCP integration: tool definition, handler, and server wiring

## Test plan
- [x] All 88 MCP tests pass (`python3 -m unittest discover -s mcp/tests`)
- [x] Pattern generator creates valid PNG with correct colors at corners
- [x] Detector finds markers when pattern is composited at various offsets (right half, full screen, quarter screen)
- [x] Transform calculator computes correct scale/offset for all test scenarios
- [ ] Manual verification: run calibrate_display tool via MCP, capture DHU screenshot, verify markers visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)