### PR TITLE
fix: bump com.google.truth to 1.4.5 to resolve duplicate version conflict

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -114,7 +114,7 @@ maven.install(
 
         # Testing
         "junit:junit:4.13.2",
-        "com.google.truth:truth:1.4.4",
+        "com.google.truth:truth:1.4.5",
         "androidx.test:core:1.6.1",
         "androidx.test.ext:junit:1.2.1",
         "org.robolectric:robolectric:4.14.1",


### PR DESCRIPTION
## Summary
- Bumps `com.google.truth:truth` from `1.4.4` to `1.4.5` in `MODULE.bazel`
- A transitive dependency already requires `1.4.5`, causing Bazel to report a duplicate artifact version warning
- Fixes #96

## Test plan
- [ ] Verify `bazel build //android/...` no longer shows duplicate version warning for `com.google.truth:truth`
- [ ] Verify existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)