### PR TITLE
feat: add phone UI with Activity + Fragment layout

### DIFF
--- a/android/BUILD.bazel
+++ b/android/BUILD.bazel
@@ -1012,3 +1012,95 @@ android_local_test(
         "@robolectric//bazel:android-all",
     ],
 )
+
+# ============================================================================
+# Phone UI library
+# ============================================================================
+
+kt_android_library(
+    name = "phone_lib",
+    srcs = glob(["app/src/main/kotlin/com/vanpilot/phone/**/*.kt"]),
+    custom_package = "com.vanpilot.auto",
+    manifest = "app/src/main/AndroidManifest.xml",
+    resource_files = glob(["app/src/main/res/**"]),
+    deps = [
+        ":vanpilot_lib",
+    ],
+)
+
+# ============================================================================
+# Phone UI test libraries
+# ============================================================================
+
+kt_jvm_library(
+    name = "phone_main_activity_test_lib",
+    srcs = ["app/src/test/kotlin/com/vanpilot/phone/PhoneMainActivityTest.kt"],
+    deps = [
+        ":phone_lib",
+        ":vanpilot_lib",
+        "@maven//:com_google_truth_truth",
+        "@maven//:junit_junit",
+        "@maven//:org_robolectric_robolectric",
+    ],
+)
+
+kt_jvm_library(
+    name = "visual_card_fragment_test_lib",
+    srcs = ["app/src/test/kotlin/com/vanpilot/phone/VisualCardFragmentTest.kt"],
+    deps = [
+        ":phone_lib",
+        ":vanpilot_lib",
+        "@maven//:com_google_truth_truth",
+        "@maven//:junit_junit",
+        "@maven//:org_robolectric_robolectric",
+    ],
+)
+
+kt_jvm_library(
+    name = "conversation_fragment_test_lib",
+    srcs = ["app/src/test/kotlin/com/vanpilot/phone/ConversationFragmentTest.kt"],
+    deps = [
+        ":phone_lib",
+        ":vanpilot_lib",
+        "@maven//:com_google_truth_truth",
+        "@maven//:junit_junit",
+        "@maven//:org_robolectric_robolectric",
+    ],
+)
+
+# ============================================================================
+# Phone UI test targets
+# ============================================================================
+
+android_local_test(
+    name = "phone_main_activity_test",
+    manifest = "app/src/main/AndroidManifest.xml",
+    resource_files = glob(["app/src/main/res/**"]),
+    test_class = "com.vanpilot.phone.PhoneMainActivityTest",
+    deps = [
+        ":phone_main_activity_test_lib",
+        "@robolectric//bazel:android-all",
+    ],
+)
+
+android_local_test(
+    name = "visual_card_fragment_test",
+    manifest = "app/src/main/AndroidManifest.xml",
+    resource_files = glob(["app/src/main/res/**"]),
+    test_class = "com.vanpilot.phone.VisualCardFragmentTest",
+    deps = [
+        ":visual_card_fragment_test_lib",
+        "@robolectric//bazel:android-all",
+    ],
+)
+
+android_local_test(
+    name = "conversation_fragment_test",
+    manifest = "app/src/main/AndroidManifest.xml",
+    resource_files = glob(["app/src/main/res/**"]),
+    test_class = "com.vanpilot.phone.ConversationFragmentTest",
+    deps = [
+        ":conversation_fragment_test_lib",
+        "@robolectric//bazel:android-all",
+    ],
+)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,8 +14,21 @@
     <application
         android:icon="@mipmap/ic_launcher"
         android:label="VanPilot"
-        android:supportsRtl="true">
+        android:supportsRtl="true"
+        android:theme="@android:style/Theme.Material.Light.NoActionBar">
 
+        <!-- Phone UI entry point -->
+        <activity
+            android:name="com.vanpilot.phone.PhoneMainActivity"
+            android:exported="true"
+            android:label="VanPilot">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <!-- Android Auto entry point -->
         <service
             android:name=".VanPilotCarAppService"
             android:exported="true"

--- a/android/app/src/main/kotlin/com/vanpilot/phone/ConversationFragment.kt
+++ b/android/app/src/main/kotlin/com/vanpilot/phone/ConversationFragment.kt
@@ -1,0 +1,99 @@
+package com.vanpilot.phone
+
+import android.app.Fragment
+import android.graphics.Typeface
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
+import com.vanpilot.auto.ConversationMessage
+import com.vanpilot.auto.R
+
+/**
+ * Fragment that displays a conversation feed for an agent.
+ *
+ * Replaces the Android Auto ListTemplate rows with standard Android
+ * TextViews in a ScrollView. Each message shows the sender and text.
+ */
+@Suppress("DEPRECATION")
+class ConversationFragment : Fragment() {
+
+    companion object {
+        private const val ARG_TITLE = "title"
+        private const val ARG_MSG_SENDERS = "msg_senders"
+        private const val ARG_MSG_TEXTS = "msg_texts"
+        private const val ARG_MSG_TIMESTAMPS = "msg_timestamps"
+
+        fun newInstance(
+            title: String,
+            messages: List<ConversationMessage>
+        ): ConversationFragment {
+            return ConversationFragment().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_TITLE, title)
+                    putStringArray(ARG_MSG_SENDERS, messages.map { it.sender }.toTypedArray())
+                    putStringArray(ARG_MSG_TEXTS, messages.map { it.text }.toTypedArray())
+                    putLongArray(ARG_MSG_TIMESTAMPS, messages.map { it.timestampMs }.toLongArray())
+                }
+            }
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_conversation, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val args = arguments ?: return
+        val title = args.getString(ARG_TITLE, "")
+        val senders = args.getStringArray(ARG_MSG_SENDERS) ?: emptyArray()
+        val texts = args.getStringArray(ARG_MSG_TEXTS) ?: emptyArray()
+
+        val titleView = view.findViewById<TextView>(R.id.conversation_title)
+        titleView.text = title
+
+        val container = view.findViewById<LinearLayout>(R.id.message_container)
+        container.removeAllViews()
+
+        if (senders.isEmpty()) {
+            val placeholder = TextView(activity).apply {
+                text = "No messages yet"
+                setPadding(16, 16, 16, 16)
+            }
+            container.addView(placeholder)
+        } else {
+            for (i in senders.indices) {
+                val messageView = buildMessageView(senders[i], texts[i])
+                container.addView(messageView)
+            }
+        }
+    }
+
+    private fun buildMessageView(sender: String, text: String): LinearLayout {
+        return LinearLayout(activity).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(8, 8, 8, 8)
+
+            val senderView = TextView(context).apply {
+                this.text = sender
+                setTypeface(null, Typeface.BOLD)
+                textSize = 12f
+            }
+            addView(senderView)
+
+            val textView = TextView(context).apply {
+                this.text = text
+                textSize = 14f
+            }
+            addView(textView)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/vanpilot/phone/PhoneMainActivity.kt
+++ b/android/app/src/main/kotlin/com/vanpilot/phone/PhoneMainActivity.kt
@@ -1,0 +1,118 @@
+package com.vanpilot.phone
+
+import android.app.Activity
+import android.graphics.Color
+import android.graphics.Typeface
+import android.os.Bundle
+import android.widget.Button
+import android.widget.LinearLayout
+import com.vanpilot.auto.ConversationTabManager
+import com.vanpilot.auto.R
+
+/**
+ * Main activity for the VanPilot phone UI.
+ *
+ * Mirrors the Android Auto TabTemplate layout:
+ * - Visual Card tab: displays the latest bitmap from the MCP server
+ * - Lead Agent tab: conversation feed from the lead agent
+ * - Sub-Agent tabs: conversation feeds for active sub-agents (up to 2)
+ *
+ * Uses framework Activity and Fragment to avoid adding new Maven deps.
+ */
+class PhoneMainActivity : Activity() {
+
+    val tabManager = ConversationTabManager.createWithMockData()
+
+    private var activeTabId: String = VISUAL_TAB_ID
+    private val tabButtons = mutableListOf<Button>()
+
+    companion object {
+        const val VISUAL_TAB_ID = "visual_card"
+        const val LEAD_AGENT_TAB_ID = ConversationTabManager.LEAD_AGENT_TAB_ID
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_phone_main)
+
+        buildTabs()
+        if (savedInstanceState == null) {
+            showFragment(VISUAL_TAB_ID)
+        }
+    }
+
+    private fun buildTabs() {
+        val tabBar = findViewById<LinearLayout>(R.id.tab_bar)
+        tabBar.removeAllViews()
+        tabButtons.clear()
+
+        addTab(tabBar, "Visual", VISUAL_TAB_ID)
+        addTab(tabBar, "Lead Agent", LEAD_AGENT_TAB_ID)
+
+        for ((index, agentId) in tabManager.getSubAgentIds().withIndex()) {
+            if (index >= ConversationTabManager.MAX_SUB_AGENT_TABS) break
+            val tabId = ConversationTabManager.subAgentTabId(agentId)
+            addTab(tabBar, agentId.replaceFirstChar { it.uppercase() }, tabId)
+        }
+
+        updateTabHighlight()
+    }
+
+    private fun addTab(tabBar: LinearLayout, title: String, tabId: String) {
+        val button = Button(this).apply {
+            text = title
+            tag = tabId
+            setOnClickListener { selectTab(tabId) }
+            val params = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            )
+            params.setMargins(4, 4, 4, 4)
+            layoutParams = params
+        }
+        tabBar.addView(button)
+        tabButtons.add(button)
+    }
+
+    fun selectTab(tabId: String) {
+        activeTabId = tabId
+        updateTabHighlight()
+        showFragment(tabId)
+    }
+
+    private fun updateTabHighlight() {
+        for (button in tabButtons) {
+            if (button.tag == activeTabId) {
+                button.setTypeface(null, Typeface.BOLD)
+                button.setBackgroundColor(Color.parseColor("#1A8A7D"))
+                button.setTextColor(Color.WHITE)
+            } else {
+                button.setTypeface(null, Typeface.NORMAL)
+                button.setBackgroundColor(Color.LTGRAY)
+                button.setTextColor(Color.BLACK)
+            }
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun showFragment(tabId: String) {
+        val fragment: android.app.Fragment = when (tabId) {
+            VISUAL_TAB_ID -> VisualCardFragment()
+            LEAD_AGENT_TAB_ID -> ConversationFragment.newInstance(
+                "Lead Agent",
+                tabManager.getLeadAgentMessages()
+            )
+            else -> {
+                val agentId = ConversationTabManager.agentIdFromTabId(tabId)
+                ConversationFragment.newInstance(
+                    agentId,
+                    tabManager.getSubAgentMessages(agentId)
+                )
+            }
+        }
+
+        fragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, fragment)
+            .commit()
+    }
+}

--- a/android/app/src/main/kotlin/com/vanpilot/phone/VisualCardFragment.kt
+++ b/android/app/src/main/kotlin/com/vanpilot/phone/VisualCardFragment.kt
@@ -1,0 +1,60 @@
+package com.vanpilot.phone
+
+import android.app.Fragment
+import android.graphics.Bitmap
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import com.vanpilot.auto.R
+
+/**
+ * Fragment that displays the latest visual card bitmap.
+ *
+ * Replaces the Android Auto SurfaceCallback approach with a standard
+ * ImageView. The bitmap is set programmatically when received via gRPC.
+ */
+@Suppress("DEPRECATION")
+class VisualCardFragment : Fragment() {
+
+    private var imageView: ImageView? = null
+    private var pendingBitmap: Bitmap? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_visual_card, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        imageView = view.findViewById(R.id.visual_card_image)
+
+        pendingBitmap?.let {
+            imageView?.setImageBitmap(it)
+            pendingBitmap = null
+        }
+    }
+
+    fun displayBitmap(bitmap: Bitmap) {
+        val iv = imageView
+        if (iv != null) {
+            iv.setImageBitmap(bitmap)
+        } else {
+            pendingBitmap = bitmap
+        }
+    }
+
+    fun clearBitmap() {
+        pendingBitmap = null
+        imageView?.setImageDrawable(null)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        imageView = null
+    }
+}

--- a/android/app/src/main/res/layout/activity_phone_main.xml
+++ b/android/app/src/main/res/layout/activity_phone_main.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <HorizontalScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:scrollbars="none">
+
+        <LinearLayout
+            android:id="@+id/tab_bar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:padding="4dp" />
+    </HorizontalScrollView>
+
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/fragment_conversation.xml
+++ b/android/app/src/main/res/layout/fragment_conversation.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/conversation_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:textSize="18sp"
+        android:textStyle="bold" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <LinearLayout
+            android:id="@+id/message_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="8dp" />
+    </ScrollView>
+</LinearLayout>

--- a/android/app/src/main/res/layout/fragment_visual_card.xml
+++ b/android/app/src/main/res/layout/fragment_visual_card.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/visual_card_image"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="fitCenter"
+        android:contentDescription="Visual card display" />
+</FrameLayout>

--- a/android/app/src/test/kotlin/com/vanpilot/phone/ConversationFragmentTest.kt
+++ b/android/app/src/test/kotlin/com/vanpilot/phone/ConversationFragmentTest.kt
@@ -1,0 +1,119 @@
+package com.vanpilot.phone
+
+import android.widget.LinearLayout
+import android.widget.TextView
+import com.google.common.truth.Truth.assertThat
+import com.vanpilot.auto.R
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.ConscryptMode
+
+/**
+ * Robolectric tests for ConversationFragment.
+ * Verifies message display and title rendering.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+@ConscryptMode(ConscryptMode.Mode.OFF)
+class ConversationFragmentTest {
+
+    private lateinit var activity: PhoneMainActivity
+
+    @Before
+    fun setUp() {
+        activity = Robolectric.buildActivity(PhoneMainActivity::class.java)
+            .create()
+            .start()
+            .resume()
+            .get()
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun fragment_isCreated() {
+        switchToLeadAgent()
+        val fragment = getConversationFragment()
+        assertThat(fragment).isNotNull()
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun fragment_showsTitle() {
+        switchToLeadAgent()
+        val fragment = getConversationFragment()
+        val titleView = fragment.view!!.findViewById<TextView>(R.id.conversation_title)
+        assertThat(titleView.text.toString()).isEqualTo("Lead Agent")
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun fragment_showsMessages() {
+        switchToLeadAgent()
+        val fragment = getConversationFragment()
+        val container = fragment.view!!.findViewById<LinearLayout>(R.id.message_container)
+        // Mock data has 3 lead agent messages
+        assertThat(container.childCount).isEqualTo(3)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun fragment_messageContainsText() {
+        switchToLeadAgent()
+        val fragment = getConversationFragment()
+        val container = fragment.view!!.findViewById<LinearLayout>(R.id.message_container)
+        // First message from mock data
+        val firstMessage = container.getChildAt(0) as LinearLayout
+        val textView = firstMessage.getChildAt(1) as TextView
+        assertThat(textView.text.toString()).isEqualTo("Starting analysis of the codebase...")
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun fragment_messageContainsSender() {
+        switchToLeadAgent()
+        val fragment = getConversationFragment()
+        val container = fragment.view!!.findViewById<LinearLayout>(R.id.message_container)
+        val firstMessage = container.getChildAt(0) as LinearLayout
+        val senderView = firstMessage.getChildAt(0) as TextView
+        assertThat(senderView.text.toString()).isEqualTo("lead")
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun fragment_noMessages_showsPlaceholder() {
+        val fragment = ConversationFragment.newInstance("Test Agent", emptyList())
+        activity.fragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, fragment)
+            .commit()
+        // Execute pending transactions
+        activity.fragmentManager.executePendingTransactions()
+
+        val container = fragment.view!!.findViewById<LinearLayout>(R.id.message_container)
+        assertThat(container.childCount).isEqualTo(1)
+        val placeholder = container.getChildAt(0) as TextView
+        assertThat(placeholder.text.toString()).isEqualTo("No messages yet")
+    }
+
+    private fun switchToLeadAgent() {
+        val tabBar = activity.findViewById<LinearLayout>(R.id.tab_bar)
+        for (i in 0 until tabBar.childCount) {
+            val child = tabBar.getChildAt(i)
+            if (child is android.widget.Button && child.text == "Lead Agent") {
+                child.performClick()
+                return
+            }
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun getConversationFragment(): ConversationFragment {
+        // Need to execute pending transactions since we use commit() not commitNow()
+        activity.fragmentManager.executePendingTransactions()
+        return activity.fragmentManager
+            .findFragmentById(R.id.fragment_container) as ConversationFragment
+    }
+}

--- a/android/app/src/test/kotlin/com/vanpilot/phone/PhoneMainActivityTest.kt
+++ b/android/app/src/test/kotlin/com/vanpilot/phone/PhoneMainActivityTest.kt
@@ -1,0 +1,120 @@
+package com.vanpilot.phone
+
+import android.widget.Button
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import com.google.common.truth.Truth.assertThat
+import com.vanpilot.auto.R
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.ConscryptMode
+
+/**
+ * Robolectric tests for PhoneMainActivity.
+ * Verifies activity lifecycle, tab layout, and fragment switching.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+@ConscryptMode(ConscryptMode.Mode.OFF)
+class PhoneMainActivityTest {
+
+    private lateinit var activity: PhoneMainActivity
+
+    @Before
+    fun setUp() {
+        activity = Robolectric.buildActivity(PhoneMainActivity::class.java)
+            .create()
+            .start()
+            .resume()
+            .get()
+    }
+
+    @Test
+    fun activity_isCreated() {
+        assertThat(activity).isNotNull()
+    }
+
+    @Test
+    fun activity_hasFragmentContainer() {
+        val container = activity.findViewById<FrameLayout>(R.id.fragment_container)
+        assertThat(container).isNotNull()
+    }
+
+    @Test
+    fun activity_hasTabBar() {
+        val tabBar = activity.findViewById<LinearLayout>(R.id.tab_bar)
+        assertThat(tabBar).isNotNull()
+    }
+
+    @Test
+    fun activity_hasVisualTab() {
+        val tabBar = activity.findViewById<LinearLayout>(R.id.tab_bar)
+        val visualTab = findTabByText(tabBar, "Visual")
+        assertThat(visualTab).isNotNull()
+    }
+
+    @Test
+    fun activity_hasLeadAgentTab() {
+        val tabBar = activity.findViewById<LinearLayout>(R.id.tab_bar)
+        val leadTab = findTabByText(tabBar, "Lead Agent")
+        assertThat(leadTab).isNotNull()
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun activity_defaultFragmentIsVisualCard() {
+        activity.fragmentManager.executePendingTransactions()
+        val fragment = activity.fragmentManager
+            .findFragmentById(R.id.fragment_container)
+        assertThat(fragment).isInstanceOf(VisualCardFragment::class.java)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun activity_selectLeadAgentTab_showsConversationFragment() {
+        val tabBar = activity.findViewById<LinearLayout>(R.id.tab_bar)
+        val leadTab = findTabByText(tabBar, "Lead Agent")!!
+        leadTab.performClick()
+        activity.fragmentManager.executePendingTransactions()
+
+        val fragment = activity.fragmentManager
+            .findFragmentById(R.id.fragment_container)
+        assertThat(fragment).isInstanceOf(ConversationFragment::class.java)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun activity_selectVisualTab_showsVisualCardFragment() {
+        // First switch to Lead Agent
+        val tabBar = activity.findViewById<LinearLayout>(R.id.tab_bar)
+        findTabByText(tabBar, "Lead Agent")!!.performClick()
+        activity.fragmentManager.executePendingTransactions()
+
+        // Then switch back to Visual
+        findTabByText(tabBar, "Visual")!!.performClick()
+        activity.fragmentManager.executePendingTransactions()
+
+        val fragment = activity.fragmentManager
+            .findFragmentById(R.id.fragment_container)
+        assertThat(fragment).isInstanceOf(VisualCardFragment::class.java)
+    }
+
+    @Test
+    fun tabManager_isAccessible() {
+        assertThat(activity.tabManager).isNotNull()
+    }
+
+    private fun findTabByText(tabBar: LinearLayout, text: String): Button? {
+        for (i in 0 until tabBar.childCount) {
+            val child = tabBar.getChildAt(i)
+            if (child is Button && child.text == text) {
+                return child
+            }
+        }
+        return null
+    }
+}

--- a/android/app/src/test/kotlin/com/vanpilot/phone/VisualCardFragmentTest.kt
+++ b/android/app/src/test/kotlin/com/vanpilot/phone/VisualCardFragmentTest.kt
@@ -1,0 +1,78 @@
+package com.vanpilot.phone
+
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import android.widget.ImageView
+import com.google.common.truth.Truth.assertThat
+import com.vanpilot.auto.R
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.ConscryptMode
+
+/**
+ * Robolectric tests for VisualCardFragment.
+ * Verifies bitmap display and placeholder rendering.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+@ConscryptMode(ConscryptMode.Mode.OFF)
+class VisualCardFragmentTest {
+
+    private lateinit var activity: PhoneMainActivity
+    private lateinit var fragment: VisualCardFragment
+
+    @Suppress("DEPRECATION")
+    @Before
+    fun setUp() {
+        activity = Robolectric.buildActivity(PhoneMainActivity::class.java)
+            .create()
+            .start()
+            .resume()
+            .get()
+        // The default fragment is VisualCardFragment
+        fragment = activity.fragmentManager
+            .findFragmentById(R.id.fragment_container) as VisualCardFragment
+    }
+
+    @Test
+    fun fragment_isCreated() {
+        assertThat(fragment).isNotNull()
+    }
+
+    @Test
+    fun fragment_hasImageView() {
+        val imageView = fragment.view!!.findViewById<ImageView>(R.id.visual_card_image)
+        assertThat(imageView).isNotNull()
+    }
+
+    @Test
+    fun displayBitmap_setsImageOnImageView() {
+        val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
+        fragment.displayBitmap(bitmap)
+
+        val imageView = fragment.view!!.findViewById<ImageView>(R.id.visual_card_image)
+        val drawable = imageView.drawable as? BitmapDrawable
+        assertThat(drawable).isNotNull()
+        assertThat(drawable!!.bitmap).isEqualTo(bitmap)
+    }
+
+    @Test
+    fun clearBitmap_removesImageFromImageView() {
+        val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
+        fragment.displayBitmap(bitmap)
+        fragment.clearBitmap()
+
+        val imageView = fragment.view!!.findViewById<ImageView>(R.id.visual_card_image)
+        assertThat(imageView.drawable).isNull()
+    }
+
+    @Test
+    fun fragment_initialImageViewHasNoDrawable() {
+        val imageView = fragment.view!!.findViewById<ImageView>(R.id.visual_card_image)
+        assertThat(imageView.drawable).isNull()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds native phone UI that mirrors the Android Auto TabTemplate layout
- `PhoneMainActivity` with button-based tab switching (Visual, Lead Agent, Sub-Agents)
- `VisualCardFragment` displays bitmaps via ImageView (replaces SurfaceCallback)
- `ConversationFragment` shows agent message feeds in ScrollView
- Both phone and AA entry points coexist in the same APK
- Uses framework `Activity`/`Fragment` — no new Maven dependencies needed

## Tests written
- `PhoneMainActivityTest` (9 tests): activity lifecycle, tab bar, fragment switching
- `VisualCardFragmentTest` (5 tests): bitmap display, clear, initial state
- `ConversationFragmentTest` (6 tests): title, messages, sender, placeholder

All 20 tests pass (3 phone + existing suite).

## Test plan
- [x] `bazel test //android:phone_main_activity_test` passes
- [x] `bazel test //android:visual_card_fragment_test` passes
- [x] `bazel test //android:conversation_fragment_test` passes
- [x] Existing AA tests (`screen_test`, `car_app_service_test`, `session_test`) still pass

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)