### PR TITLE
feat: add launchd service for instance manager

### DIFF
--- a/instance_manager/install-im-service.sh
+++ b/instance_manager/install-im-service.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Install or uninstall the VanPilot Instance Manager launchd service.
+#
+# Usage:
+#   ./instance_manager/install-im-service.sh              # install & start
+#   ./instance_manager/install-im-service.sh --uninstall  # stop & remove
+#   ./instance_manager/install-im-service.sh --status     # show service status
+set -euo pipefail
+
+LABEL="photos.apw.vanpilot.instance-manager"
+PLIST_SRC="$(cd "$(dirname "$0")" && pwd)/${LABEL}.plist"
+PLIST_DST="$HOME/Library/LaunchAgents/${LABEL}.plist"
+VANPILOT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+IM_ZIP_SRC="$VANPILOT_ROOT/bazel-bin/instance_manager/instance_manager.zip"
+INSTALL_DIR="$HOME/Library/Application Support/VanPilot"
+IM_ZIP_DST="$INSTALL_DIR/instance_manager.zip"
+
+status() {
+    if launchctl list "$LABEL" &>/dev/null; then
+        echo "Service is loaded."
+        launchctl list "$LABEL"
+    else
+        echo "Service is not loaded."
+    fi
+}
+
+uninstall() {
+    echo "Stopping and unloading ${LABEL}..."
+    launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+    rm -f "$PLIST_DST"
+    echo "Uninstalled. (Binary left at $IM_ZIP_DST — remove manually if desired.)"
+}
+
+install() {
+    if [ ! -f "$IM_ZIP_SRC" ]; then
+        echo "ERROR: Instance manager zip not found at:" >&2
+        echo "  $IM_ZIP_SRC" >&2
+        echo "" >&2
+        echo "Build it first with:" >&2
+        echo "  cd $VANPILOT_ROOT && bazel build //instance_manager:instance_manager_zip" >&2
+        exit 1
+    fi
+
+    # Copy zip outside the git/bazel tree so bazel clean won't delete it
+    mkdir -p "$INSTALL_DIR"
+    cp "$IM_ZIP_SRC" "$IM_ZIP_DST"
+    echo "Copied instance_manager.zip to $IM_ZIP_DST"
+
+    # Ensure log directory exists
+    mkdir -p "$HOME/Library/Logs"
+
+    # Unload existing service if present
+    launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+
+    # Generate plist with resolved paths
+    sed \
+        -e "s|__INSTANCE_MANAGER_ZIP__|${IM_ZIP_DST}|g" \
+        -e "s|__VANPILOT_ROOT__|${VANPILOT_ROOT}|g" \
+        -e "s|__HOME__|${HOME}|g" \
+        "$PLIST_SRC" > "$PLIST_DST"
+
+    echo "Installed plist to $PLIST_DST"
+
+    # Load and start
+    launchctl bootstrap "gui/$(id -u)" "$PLIST_DST"
+    echo "Service loaded. Checking status..."
+    sleep 1
+    status
+
+    echo ""
+    echo "Logs: tail -f ~/Library/Logs/vanpilot-im.log"
+}
+
+case "${1:-}" in
+    --uninstall) uninstall ;;
+    --status)    status ;;
+    *)           install ;;
+esac

--- a/instance_manager/photos.apw.vanpilot.instance-manager.plist
+++ b/instance_manager/photos.apw.vanpilot.instance-manager.plist
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  VanPilot Instance Manager — launchd service
+
+  Install:  ./instance_manager/install-im-service.sh
+  Remove:   ./instance_manager/install-im-service.sh --uninstall
+  Logs:     tail -f ~/Library/Logs/vanpilot-im.log
+  Status:   launchctl list photos.apw.vanpilot.instance-manager
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>photos.apw.vanpilot.instance-manager</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/python3</string>
+        <string>__INSTANCE_MANAGER_ZIP__</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__VANPILOT_ROOT__</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/vanpilot-im.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/vanpilot-im.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>ANDROID_HOME</key>
+        <string>/opt/homebrew/share/android-commandlinetools</string>
+        <key>ANDROID_SDK_ROOT</key>
+        <string>/opt/homebrew/share/android-commandlinetools</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/opt/homebrew/share/android-commandlinetools/platform-tools:/opt/homebrew/share/android-commandlinetools/emulator:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
+    <key>ProcessType</key>
+    <string>Interactive</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Adds a `launchd` plist template and install/uninstall script so the instance manager starts on login and auto-restarts on crash
- Binary is copied to `~/Library/Application Support/VanPilot/` at install time so `bazel clean` won't break the running service
- Closes #157

## Usage

```bash
# Build the server zip first
bazel build //instance_manager:instance_manager_zip

# Install & start the service
./instance_manager/install-im-service.sh

# Check status
./instance_manager/install-im-service.sh --status

# Uninstall
./instance_manager/install-im-service.sh --uninstall

# Logs
tail -f ~/Library/Logs/vanpilot-im.log
```

## Test plan

- [x] `bazel build //instance_manager:instance_manager_zip` produces the zip
- [x] `./instance_manager/install-im-service.sh` installs and starts the service
- [x] `launchctl list photos.apw.vanpilot.instance-manager` shows PID and exit status 0
- [x] `kill -9 <pid>` → service restarts within seconds
- [x] `./instance_manager/install-im-service.sh --uninstall` removes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)